### PR TITLE
feat: #25 reintegrar Track I con vistas P4 tras merge dev

### DIFF
--- a/backend/src/main/java/com/impaintor/feature/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/impaintor/feature/auth/config/SecurityConfig.java
@@ -27,6 +27,9 @@ public class SecurityConfig {
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/auth/**").permitAll()
+                // El handshake HTTP del WebSocket no pasa por filtros de auth — el JWT
+                // se valida en el frame STOMP CONNECT (ver Track D, JwtChannelInterceptor).
+                .requestMatchers("/ws/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/users/leaderboard").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/users/me").authenticated()
                 .requestMatchers(HttpMethod.PUT, "/api/users/me").authenticated()

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -12,12 +12,17 @@ spring:
     exclude:
       - org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
 
+# JWT compartido por Track A (JwtService) y Track D (JwtTokenValidator) en tests.
+jwt:
+  secret: test-secret-test-secret-test-secret-test-secret-test
+  expiration-ms: 3600000
+
 impaintor:
   realtime:
     broker:
       mode: simple
     jwt:
-      secret: test-secret-test-secret-test-secret-test-secret-test
+      secret: ${jwt.secret}
       issuer: impaintor-test
     websocket:
       endpoint: /ws

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -19,6 +19,12 @@ spring:
 server:
   port: ${SERVER_PORT:8080}
 
+# Configuración JWT compartida por Track A (JwtService) y Track D (JwtTokenValidator)
+# para garantizar que firman/validan con la misma clave.
+jwt:
+  secret: ${IMPAINTOR_JWT_SECRET:dev-secret-change-me-dev-secret-change-me-dev-secret}
+  expiration-ms: ${JWT_EXPIRATION_MS:86400000}   # 24h por defecto
+
 impaintor:
   realtime:
     broker:
@@ -28,8 +34,8 @@ impaintor:
       relay-login: ${SPRING_RABBITMQ_USERNAME:guest}
       relay-passcode: ${SPRING_RABBITMQ_PASSWORD:guest}
     jwt:
-      # PENDING — Track A debe firmar tokens con este mismo secret. En prod, sobreescribir vía env.
-      secret: ${IMPAINTOR_JWT_SECRET:dev-secret-change-me-dev-secret-change-me-dev-secret}
+      # Reutiliza el mismo secret raíz que Track A para que ambos firmen/validen igual.
+      secret: ${jwt.secret}
       issuer: impaintor
     websocket:
       endpoint: /ws

--- a/docs/p4-log.md
+++ b/docs/p4-log.md
@@ -1,0 +1,383 @@
+# P4 — Log de trabajo
+
+Diario personal de P4 (José). Registra qué se hizo, cuándo y por qué. No es un handoff: para reparto y planificación de Track I, ver [track-i-plan.md](./track-i-plan.md). Para SPIs/contratos disponibles, ver el código bajo `com.impaintor.feature.realtime` y los comentarios `// PENDING — Track X`.
+
+---
+
+## Índice (orden cronológico)
+
+1. [Track D — Infraestructura en Tiempo Real (Fase 1, completado)](#1-track-d--infraestructura-en-tiempo-real)
+2. [CI backend (GitHub Actions)](#2-ci-backend-github-actions)
+3. [Stub temporal de `User` (PENDING — Track A)](#3-stub-temporal-de-user-pending--track-a)
+4. [Track I Fase 1 + 2 — foundation + container (entregado 2026-05-06)](#4-track-i-fase-1--2--foundation--container-entregado-2026-05-06)
+5. [Track I — vistas P4 + cierre §4.6 (entregado 2026-05-06)](#5-track-i--vistas-p4--cierre-46-entregado-2026-05-06)
+6. [Track I — fix-up sobre review de Copilot (entregado 2026-05-06)](#6-track-i--fix-up-sobre-review-de-copilot-entregado-2026-05-06)
+7. [Reintegración tras merge de `dev` (entregado 2026-05-14)](#7-reintegraci%C3%B3n-tras-merge-de-dev-entregado-2026-05-14)
+
+---
+
+## 1. Track D — Infraestructura en Tiempo Real
+
+Track D cubre las tareas **1D.1 → 1D.6** de la Fase 1: configuración WebSocket/STOMP/RabbitMQ, validación JWT en CONNECT, gestión de topics por sala, retransmisión de trazos, difusión de eventos del juego y entrega de mensajes privados.
+
+### 1.1 Resumen de entregables
+
+- **Phase 0 catch-up** (no estaba hecho cuando arranqué):
+  - Clase main: [backend/src/main/java/com/impaintor/ImpaintorApplication.java](../backend/src/main/java/com/impaintor/ImpaintorApplication.java)
+  - Boilerplate de test reubicado de `com.example.demo` a `com.impaintor`
+  - `pom.xml` con jjwt 0.12.6, H2 (test scope), `groupId/artifactId` corregidos a `com.impaintor:impaintor-backend`
+  - `application.yml` con env-vars (compatible Docker), `application-test.yml` con H2 y SimpleBroker
+  - [backend/Dockerfile](../backend/Dockerfile) (multi-stage maven → jre-alpine)
+  - [docker-compose.yml](../docker-compose.yml) con backend + Postgres + RabbitMQ con plugin STOMP en :61613
+
+- **Track D** (todo bajo `com.impaintor.feature.realtime`):
+  - `config/WebSocketConfig` — `@EnableWebSocketMessageBroker`, modo `relay` (RabbitMQ) en producción, `simple` (in-memory) en tests, según el property `impaintor.realtime.broker.mode`
+  - `config/RealtimeProperties` — `@ConfigurationProperties("impaintor.realtime")` tipado con records
+  - `config/RealtimeSecurityConfig` — `SecurityFilterChain` mínimo, `@ConditionalOnMissingBean` para que Track A lo reemplace
+  - `config/RealtimeStubsConfig` — registra los stubs de los SPIs vía `@Bean @ConditionalOnMissingBean`
+  - `security/TokenValidator` (interfaz SPI) + `JwtTokenValidator` (impl real con jjwt) + `JwtChannelInterceptor` + `StompPrincipal` + `AuthenticatedUser`
+  - `topic/RoomTopicRegistry` (registro thread-safe) + `RoomMembershipChecker` (SPI) + `AlwaysAllowMembershipChecker` (stub)
+  - `dto/inbound/`: `DrawCommand` sealed con `StrokeMessage` y `ClearCanvasMessage` (Jackson polymorphic con `type` discriminator), `VoteMessage`, `GuessMessage`, `Point`
+  - `dto/outbound/`: `StrokeBroadcast`, `ClearCanvasBroadcast`, `GameEvent` sealed con 10 variantes record (Jackson `@JsonTypeInfo` por `type`), `RoleAssignment` sealed (Painter / Impostor), `GuessResult`
+  - `controller/DrawWebSocketController` — `@MessageMapping("/room.{code}.draw")` único con discriminador `type`, anti-spoofing (usa el id del Principal, no del payload)
+  - `controller/GameInputWebSocketController` — `@MessageMapping("/room.{code}.vote")` y `/guess`, delega a `GameInputHandler`
+  - `service/RealtimePublisher` — fachada tipada sobre `SimpMessagingTemplate` para que Track H emita eventos sin conocer detalles STOMP/RabbitMQ
+  - `service/GameInputHandler` (SPI) + `LoggingGameInputHandler` (stub con logs)
+
+### 1.2 Tests (TDD estricto, 39/39 verdes)
+
+- 6 `JwtTokenValidatorTest`
+- 6 `JwtChannelInterceptorTest`
+- 5 `RoomTopicRegistryTest`
+- 7 `RealtimePublisherTest`
+- 4 `DrawWebSocketControllerTest`
+- 4 `GameInputWebSocketControllerTest`
+- 3 `WebSocketConfigTest`
+- 3 `WebSocketIntegrationTest` (cliente STOMP real con SimpleBroker)
+- 1 `ImpaintorApplicationTests`
+
+### 1.3 Decisiones de diseño relevantes
+
+1. **Modo broker condicional vía properties** (no `@Profile`) — más explícito y testeable.
+2. **DTOs sealed + records con discriminador `type` en JSON** — espejo del formato de la sec 6.2 de CLAUDE.md, validable por Jackson.
+3. **Anti-spoofing en controllers**: el `playerId`/`voterId` siempre se lee del `Principal` autenticado, no del payload del cliente.
+4. **`MessageHeaderAccessor.getAccessor` con mutación in-place** en `JwtChannelInterceptor` — única forma de que el `Principal` propague a la sesión WebSocket en frames SEND posteriores. Necesita `setLeaveMutable(true)` en los headers (Spring lo hace por defecto en producción; en los tests unitarios lo añadimos manualmente).
+5. **`@ConditionalOnMissingBean` solo en `@Bean`** (no en `@Component` — no funciona ahí). Por eso los stubs son `@Bean` en `RealtimeStubsConfig`.
+6. **Test de integración con `SimpleBroker` en lugar de Testcontainers RabbitMQ** — más rápido, no requiere Docker en CI, y verifica el wiring real de mappings + broadcast.
+
+### 1.4 Cómo correrlo
+
+```bash
+cd backend
+./mvnw test                  # 39 tests verdes
+./mvnw -DskipTests package   # JAR ejecutable
+docker-compose up --build    # stack completo (backend + db + rabbitmq)
+```
+
+Consola RabbitMQ (dev): http://localhost:15672 (impaintor / impaintor).
+
+---
+
+## 2. CI backend (GitHub Actions)
+
+Workflow: [.github/workflows/backend-ci.yml](../.github/workflows/backend-ci.yml)
+
+**Triggers:**
+- `push` a la rama `dev` con cambios bajo `backend/**` o el propio workflow.
+- `pull_request` contra `main` con cambios bajo `backend/**` o el propio workflow.
+
+**Pipeline:**
+1. `actions/checkout@v4`
+2. `actions/setup-java@v4` con JDK 17 Temurin y cache Maven (~/.m2)
+3. `chmod +x mvnw` (mvnw está tracked como `100644`, no como ejecutable, para evitar problemas en checkouts Windows)
+4. `./mvnw -B -DskipTests compile`
+5. `./mvnw -B test`
+
+Si tocas algo en `frontend/`, `docker-compose.yml` o `CLAUDE.md`, **el CI no corre** — diseño deliberado para que P5/P6/Track E,F,G no sufran nuestros tiempos de CI.
+
+---
+
+## 3. Stub temporal de `User` (PENDING — Track A)
+
+### 3.1 Por qué existe
+
+El día del merge a `dev`, Track B había mergeado `Room` y `RoomController` con `import com.impaintor.feature.user.models.User;` en dos archivos:
+
+- [backend/src/main/java/com/impaintor/feature/room/models/Room.java](../backend/src/main/java/com/impaintor/feature/room/models/Room.java) — campo `@ManyToMany List<User> playersNames`.
+- [backend/src/main/java/com/impaintor/feature/room/controller/RoomController.java](../backend/src/main/java/com/impaintor/feature/room/controller/RoomController.java) — `@RequestBody User user` en endpoints `join`/`leave`.
+
+Pero **Track A todavía no estaba mergeado** — el paquete `com.impaintor.feature.user.models` no existía y la compilación entera (todos los tests, todo el build) estaba rota. El CI lo expuso al primer `mvn clean compile`.
+
+### 3.2 Solución temporal
+
+Creé un **stub mínimo** en [backend/src/main/java/com/impaintor/feature/user/models/User.java](../backend/src/main/java/com/impaintor/feature/user/models/User.java) con los campos de la sec 4.1 de CLAUDE.md (`id`, `email`, `username`, `password`, `elo`, `gamesPlayed`, `gamesWon`, `createdAt`) más Lombok `@Getter`/`@Setter`/`@NoArgsConstructor`.
+
+Es un `@Entity` con `@Table(name = "users")` para que el `@JoinTable(inverseJoinColumns = @JoinColumn(name = "user_id"))` de `Room` se resuelva.
+
+### 3.3 Cuándo borrarlo
+
+Cuando Track A merge su `User.java` real. Si los nombres de campos de la sec 4.1 de CLAUDE.md se respetan, el merge es trivial. Recordatorio buscable:
+
+```bash
+grep -r "STUB PROVISIONAL" backend/src/main/java
+```
+
+---
+
+## 4. Track I Fase 1 + 2 — foundation + container (entregado 2026-05-06)
+
+Ejecución parcial del [plan de Track I](./track-i-plan.md): Foundation (modelos + servicios + mock) y container con state machine. Las 6 sub-vistas (Fase 3) quedan como **placeholders visuales** para que cualquier sustitución TDD posterior (P3 o yo) no toque el container.
+
+**Comando de verificación:** `cd frontend && npm test` → 37 tests míos verdes (1 test rojo en `app.spec.ts` preexistente del scaffold de Track G — Canvas API en jsdom; ajeno a Track I y al trabajo P4).
+**Build de producción:** `npm run build` OK, lazy chunk `game` separado correctamente, SSR sin warnings nuevos.
+
+### 4.1 Estado por archivo (qué es qué)
+
+| Archivo | Estado | Notas |
+|---|---|---|
+| `frontend/package.json` | ✅ Implementado | añadidos `@stomp/stompjs`, `sockjs-client`, `@types/sockjs-client` |
+| `frontend/proxy.conf.json` | ✅ Implementado | reenvía `/api` y `/ws` al backend en :8080 |
+| `frontend/angular.json` | ✅ Implementado | `serve.options.proxyConfig` apuntando al proxy |
+| `frontend/src/app/app.routes.ts` | ✅ Implementado | ruta lazy `/room/:code/game` |
+| `frontend/src/app/app.routes.server.ts` | ✅ Implementado | `RenderMode.Client` para `/room/**`, prerender para el resto |
+| `frontend/src/app/core/auth/token.ts` | ⏸️ PENDING — Track E | helper `getStoredToken()` lee `localStorage['jwt']`. Track E lo reemplaza con `AuthService.getToken()` |
+| `frontend/src/app/features/realtime/models/stomp.ts` | ⏸️ PENDING — Track F | tipos `ConnectionStatus`, `StompConfig` |
+| `frontend/src/app/features/realtime/services/stomp-client.ts` | ⏸️ PENDING — Track F | wrapper @stomp/stompjs SSR-safe. **Funcional y testeado**, pero F aporta su versión definitiva |
+| `frontend/src/app/features/realtime/services/stomp-client.spec.ts` | ✅ Implementado | 5 tests verdes (connect/status$/subscribe/send/disconnect) |
+| `frontend/src/app/features/game/models/game-event.ts` | ✅ Implementado | discriminated union de los 10 GameEvent + `StrokeBroadcast`/`ClearCanvasBroadcast` (espejo del backend Track D) |
+| `frontend/src/app/features/game/models/role-assignment.ts` | ✅ Implementado | RoleAssignment + GuessResult + PrivateMessage |
+| `frontend/src/app/features/game/models/game-state.ts` | ✅ Implementado | `Phase`, `GameState`, `INITIAL_STATE` |
+| `frontend/src/app/features/game/services/game-state.ts` | ✅ Implementado | store con signals + reducer exhaustivo + `gameEvents$` para SFX (P6) |
+| `frontend/src/app/features/game/services/game-state.spec.ts` | ✅ Implementado | 18 tests verdes — un caso por handler de evento + selectores + reset |
+| `frontend/src/app/features/game/services/mock-game-event-emitter.ts` | 🟡 Stub propio (dev-only) | reproduce un guion de 18 eventos para que `?dev=true` funcione sin backend Track H |
+| `frontend/src/app/features/game/containers/game/game.{ts,html,css}` | ✅ Implementado | container con state machine, `@switch` exhaustivo, slot `[impostorOverlay]` para P6 |
+| `frontend/src/app/features/game/containers/game/game.spec.ts` | ✅ Implementado | 7 tests verdes — uno por fase + caso "no autenticado" + caso "ngOnDestroy desconecta" |
+| `frontend/src/app/features/game/components/drawing-phase-view/*` | 🟡 Placeholder propio | renderiza `<h2>Fase: DRAWING</h2><pre>{{state\|json}}</pre>` (sec 2I.2) |
+| `frontend/src/app/features/game/components/gallery-view/*` | 🟡 Placeholder propio | idem (sec 2I.3) |
+| `frontend/src/app/features/game/components/voting-view/*` | 🟡 Placeholder propio | idem (sec 2I.4) |
+| `frontend/src/app/features/game/components/tie-break-view/*` | 🟡 Placeholder propio | idem (sec 2I.5) |
+| `frontend/src/app/features/game/components/vote-result-view/*` | 🟡 Placeholder propio | idem (sec 2I.6) |
+| `frontend/src/app/features/game/components/game-over-view/*` | 🟡 Placeholder propio | idem (sec 2I.7) |
+
+### 4.2 Lo que NO está implementado (consciente)
+
+- **Sub-vistas reales (2I.2 → 2I.7)**: solo placeholders — la sustitución concreta sigue las indicaciones del plan.
+- **2I.8 — UI flotante del impostor (P6)**: ya hay slot `<ng-content select="[impostorOverlay]">` en `game.html` y signals expuestos en `GameStateService` (`isImpostor()`, `hint()`, `impostorLives()`).
+- **2I.9 — SFX (P6)**: `GameStateService.gameEvents$` (Subject) está listo para que `AudioService` se subscribe.
+- **Tests de integración con backend Track H real**: Track H no existe todavía. Yo controlo ambos espejos JSON (backend Track D + frontend Track I), riesgo bajo cuando llegue.
+- **Estilo visual**: Tailwind disponible pero los placeholders son CSS plano — no quería condicionar a Track K.
+
+### 4.3 Decisiones técnicas de esta entrega
+
+1. **Mock del `Client` de `@stomp/stompjs` con clase, no `vi.fn().mockImplementation`** — `vi.fn()` no es invocable con `new`. Patrón de mock anotado en `stomp-client.spec.ts`.
+2. **Reducer exhaustivo con `default: const _: never = e`** — TypeScript valida en compilación que cualquier `GameEvent` nuevo tiene su case. Esto pillará bugs de regresión cuando crezca la spec.
+3. **Switch en template con `@switch (gameState.phase())`** — Angular 21 control flow nativo, sin `*ngIf` chains. Más legible.
+4. **`MockGameEventEmitter` con `setTimeout` no inyecta timer** — para tests del container uso `mock.emit(event)` sincrónico, no `playFullGameScript()`. El script real solo se usa en demo `?dev=true`.
+5. **`Storage.prototype.getItem` con `vi.spyOn` en tests** — no `window.localStorage.__proto__` (el strict de TS lo bloquea).
+
+### 4.4 Cómo verificar el estado actual
+
+```bash
+cd frontend
+npm install      # solo la primera vez
+npm test         # 37 tests verdes
+npm run build    # bundle producción OK
+npm start        # ng serve en :4200
+
+# En el navegador:
+#   http://localhost:4200/room/TEST/game?dev=true   → demo modo offline (placeholders avanzando)
+#   http://localhost:4200/room/TEST/game            → modo real (requiere JWT en localStorage y backend up)
+```
+
+En el demo `?dev=true` se ve la cabecera azul "🛠️ MODO DEV", luego cada placeholder cambia automáticamente cada ~1.5 s siguiendo el guion: CONNECTING → DRAWING → … → OVER.
+
+---
+
+## 5. Track I — vistas P4 + cierre §4.6 (entregado 2026-05-06)
+
+Segunda entrega de Track I: implementación real de las 3 sub-vistas que me tocan según el reparto del [plan §4.5](./track-i-plan.md), más el `SpectatorCanvasService` que cierra el gap de §4.6 con la opción B (servicio dedicado).
+
+**Comando de verificación:** `cd frontend && npm test` → 77 tests míos verdes (1 test rojo en `app.spec.ts` preexistente del scaffold de Track G — Canvas API en jsdom; ajeno).
+**Build de producción:** `npm run build` OK, lazy chunk `game` ahora 47 kB (antes 34 kB) con las vistas reales incluidas.
+
+### 5.1 Decisión cerrada — §4.6 Opción B
+
+Resolví el gap de populación de `state.canvases` con un servicio dedicado `SpectatorCanvasService` (Opción B). Razones documentadas en [track-i-plan.md §4.6](./track-i-plan.md). Decisión tomada autónomamente con autorización explícita del usuario y marcada como **reversible** si P3 al pair-program prefiere otra opción.
+
+### 5.2 Estado por archivo (delta sobre la entrega anterior)
+
+| Archivo | Estado | Notas |
+|---|---|---|
+| `frontend/src/app/features/game/services/spectator-canvas.ts` | ✅ Implementado | Mantiene HTMLCanvasElement off-screen por jugador, expone `snapshots` signal, reset auto en GAME_START/NEW_ROUND |
+| `frontend/src/app/features/game/services/spectator-canvas.spec.ts` | ✅ Implementado | 9 tests verdes (replay, clear, reset por evento, dispatch broadcast) |
+| `frontend/src/app/features/game/components/drawing-phase-view/*` | ✅ Implementado (real) | Canvas activo si PAINTER + mi turno; modo espectador con `<img>` en otro caso; banner palabra/pista/vidas; caja inline impostor (fallback hasta P6 entregue 2I.8) |
+| `frontend/src/app/features/game/components/drawing-phase-view/*.spec.ts` | ✅ Implementado | 11 tests verdes (rol, my-turn vs espectador, fallback impostor, timer, no-drawer) |
+| `frontend/src/app/features/game/components/voting-view/*` | ✅ Implementado (real) | Grid de tarjetas con miniatura del SpectatorCanvasService; click vota; lock tras voto; excluye eliminados |
+| `frontend/src/app/features/game/components/voting-view/*.spec.ts` | ✅ Implementado | 9 tests verdes (cards, miniaturas, voteCast emit, lock, eliminado, timer, sin-snapshot) |
+| `frontend/src/app/features/game/components/game-over-view/*` | ✅ Implementado (real) | Banner ganador, reveal de palabra/pista/impostor/rondas, traducción humana de EndReason, botón playAgain |
+| `frontend/src/app/features/game/components/game-over-view/*.spec.ts` | ✅ Implementado | 11 tests verdes (winner, reveal, parametric por EndReason, playAgain emit, defensivo si gameOver null) |
+| `frontend/src/app/features/game/containers/game/game.{ts,html}` | ✅ Modificado | Inyecta SpectatorCanvasService; nueva subscripción a `/topic/room.{code}.draw`; nuevos handlers `sendStroke`, `sendVote`, `sendGuess`, `onPlayAgain`; pasa `myPlayerId` a las vistas (en dev = 42) |
+
+### 5.3 Lo que sigue siendo placeholder (para P3)
+
+- 2I.3 `GalleryView` — falta cuadrícula real (puede consumir `SpectatorCanvasService.snapshots()`)
+- 2I.5 `TieBreakView` — falta destacar `state.tiedPlayers` y opción de mover voto si IMPOSTOR
+- 2I.6 `VoteResultView` — falta revelar `state.eliminated` y `state.wasImpostorEliminated`
+
+### 5.4 Decisiones técnicas de esta entrega
+
+1. **Opción B (servicio dedicado) sobre A (en GameStateService)**: razón principal — mantener `GameStateService` puro y los 18 tests previos sin cambios. Detalle completo en [track-i-plan.md §4.6](./track-i-plan.md).
+2. **`<img>` en lugar de `<canvas>` para miniaturas espectador**: el servicio mantiene canvas off-screen y emite dataURL en cada stroke. Coste ~mínimo para ≤8 jugadores y simplifica el binding (`<img [src]="snapshots()[id]">`). Si la carga de strokes crece mucho, fácil optimizar con throttle del `toDataURL` por stroke.
+3. **Caja de adivinación inline en DrawingPhaseView (fallback impostor)**: en lugar de slot vacío hasta que P6 termine 2I.8. Marcada como PENDING en código y comentario en HTML para que P6 sepa que cuando entregue su overlay, hay que quitar este bloque inline.
+4. **`myPlayerId` hardcoded a 42 en dev mode**: coincide con el guion del MockGameEventEmitter (el primer jugador del `drawingOrder`). Cuando Track E mergee, se decodifica del JWT.
+5. **Mock de Canvas API por test, no global**: `vi.spyOn(HTMLCanvasElement.prototype, 'getContext')` solo en los specs que lo necesitan. No toco la config global de Vitest para no afectar al test preexistente roto del scaffold (responsabilidad de Track G).
+6. **EndReason traducido en el componente, no en GameStateService**: es UI text, no estado. Mantiene el servicio data-only.
+7. **Todos los componentes mantienen `data-testid="<phase>-phase"` en el root**: contrato con los tests del container, garantiza que el `@switch` sigue eligiendo el componente correcto sin importar cómo se reescriba el resto del DOM.
+
+### 5.5 Cómo verificarlo
+
+```bash
+cd frontend
+npm test         # 77 tests míos verdes
+npm run build    # bundle producción OK
+npm start        # ng serve en :4200
+```
+
+En `http://localhost:4200/room/TEST/game?dev=true` ahora se ven las 3 vistas reales (Drawing/Voting/GameOver) durante el guion automático del MockGameEventEmitter. Las miniaturas en VotingView salen como placeholder "(sin dibujo)" porque el mock no simula strokes — comportamiento esperado, marcado en docs.
+
+---
+
+## 6. Track I — fix-up sobre review de Copilot (entregado 2026-05-06)
+
+GitHub Copilot revisó el PR y dejó 8 observaciones; las 8 eran válidas. Fix-up commit aplicando todas, ordenadas por gravedad.
+
+**Comando de verificación:** `cd frontend && npm test` → 86 tests míos verdes (1 rojo preexistente ajeno). `npm run build` OK.
+
+### 6.1 Críticos (bugs reales)
+
+**#7 + #8 — strokes nunca llegaban al backend** (core de Track I roto). `DrawingPhaseView` declaraba `@Output strokeEmitted` pero nunca lo emitía: el `<app-canvas>` escribía en `CanvasService.emitStroke()` y nadie se subscribía para reenviar. Además `sendStroke()` estaba hardcoded a `STROKE` y no soportaba `CLEAR`.
+
+Fix:
+- Nuevo tipo `DrawCommand` en `models/game-event.ts`: union `{type:'STROKE',...} | {type:'CLEAR'}` (sin `playerId`, lo añade el server desde el Principal).
+- `DrawingPhaseView` ahora se subscribe a `CanvasService.getStrokeEmitter()` en `ngOnInit`, filtra por `canDraw()`, mapea al formato `DrawCommand` y emite por nuevo `@Output drawCommand`. Limpia la suscripción en `ngOnDestroy`.
+- `GameComponent.sendStroke` reemplazado por `sendDraw(cmd: DrawCommand)` que envía directamente sin reconstrucción.
+- `game.html`: `(strokeEmitted)="sendStroke($event)"` → `(drawCommand)="sendDraw($event)"`.
+- 5 tests nuevos en `drawing-phase-view.spec.ts` (STROKE emite, CLEAR emite, no-mi-turno no emite, IMPOSTOR defensiva no emite, ngOnDestroy desuscribe).
+
+**#1 — `subscribe()` antes de CONNECT.** En `connectStomp()` el `connect()` activa el cliente asíncronamente y `subscribe()` se llamaba acto seguido sincrónicamente. En `@stomp/stompjs` esto puede perder la sub o lanzar.
+
+Fix:
+- `StompClientService` mantiene una cola `pendingSubs[]` cuando `_status$.value !== 'CONNECTED'`. Al recibir `onConnect`, hace `flushPendingSubs()` y aplica todas las pendientes. La condición usa el status real (no `client.active`) porque `active` puede ser `true` desde antes del handshake STOMP completo.
+- `unsubscribe` en una sub pendiente la marca como `cancelled` para no aplicarla al CONNECT.
+- 3 tests nuevos en `stomp-client.spec.ts` (subscribe-before-connect, subscribe-after-connect, unsubscribe en pendiente).
+
+### 6.2 Medios
+
+**#4 — botón "jugar otra vez" muerto.** `onPlayAgain()` estaba vacío. Fix: `router.navigate(['/'])` para no dejar UI sin efecto. Cuando Track F defina el flujo definitivo (volver al lobby, crear nueva sala), se reemplaza la línea.
+
+**#2 — `reconnectAttempts` declarado pero no usado.** `StompConfig` documentaba "delay crece linealmente" pero la impl pasaba un valor fijo a `@stomp/stompjs`. Inconsistencia. Fix: quitado el campo `reconnectAttempts` del modelo y ajustado el comentario de `reconnectDelayMs` a "delay constante de reconexión (default 5000)". Implementar backoff real es over-engineering en este momento.
+
+### 6.3 Menores (cleanup)
+
+**#3 — duplicación de lectura de JWT.** `GameComponent.readStoredToken()` y la const `TOKEN_KEY` repetían lo de `core/auth/token.ts`. Fix: importo `getStoredToken` y lo invoco como **field initializer** (`private readonly storedToken = getStoredToken()`) — único contexto de inyección válido fuera del constructor (Angular 21). Borrados `readStoredToken`, `TOKEN_KEY` local, e imports `PLATFORM_ID` / `isPlatformBrowser`.
+
+**#5 — `myPlayerId` no usado en VotingView.** Per CLAUDE.md sec 2.3 los jugadores SÍ pueden votarse a sí mismos (auto-voto), así que no se filtra. En su lugar marco la tarjeta del jugador local con etiqueta visual `(Tú)` (chip azul). Test nuevo verifica que la etiqueta aparece solo en `myPlayerId` y en ninguna otra tarjeta.
+
+**#6 — import `timer` no usado en `mock-game-event-emitter.ts`.** Quitado.
+
+### 6.4 Nuevos contadores
+
+| Antes | Después | Delta |
+|---|---|---|
+| 77 tests míos verdes | 86 tests míos verdes | +9 (5 wiring strokes, 3 cola subs, 1 etiqueta Tú) |
+| Lazy chunk `game`: 56 kB | Lazy chunk `game`: 57 kB | +1 kB (refactor) |
+
+---
+
+## 7. Reintegración tras merge de `dev` (entregado 2026-05-14)
+
+Mientras la PR estaba abierta, los compañeros mergearon su trabajo a `dev`: Track A (Auth + `User` real + `JwtService` + `SecurityConfig`), Track B (Rooms con `RoomController` y `Lobby`), Track C (WordGroup completo) y los scaffolds de Tracks E/F/G (login, register, home, lobby, etc.). Hubo conflictos en archivos compartidos (`angular.json`, `app.routes.ts`, `app.routes.server.ts`, `app.html`, `app.ts`, `pom.xml`) que se resolvieron manualmente trasladando los cambios míos encima del nuevo HEAD.
+
+Tras la resolución manual, el backend dejó de compilar y los tests fallaban. Encontré dos causas de integración con Track A que tuve que arreglar:
+
+### 7.1 `jwt.secret` no compartido entre Track A y Track D
+
+**Síntoma:** `mvn test` → 7 errores `Could not resolve placeholder 'jwt.secret' in value "${jwt.secret}"` al cargar el `ApplicationContext`.
+
+**Causa:** Track A introdujo `JwtService` con `@Value("${jwt.secret}")` y `@Value("${jwt.expiration-ms}")`, pero mi `application.yml` solo definía `impaintor.realtime.jwt.secret`. Era exactamente uno de los items del checklist de coordinación cruzada que dejé en [track-i-plan.md §5](./track-i-plan.md).
+
+**Fix** ([application.yml](../backend/src/main/resources/application.yml) + [application-test.yml](../backend/src/main/resources/application-test.yml)):
+
+```yaml
+# Bloque raíz nuevo, compartido por Track A y Track D.
+jwt:
+  secret: ${IMPAINTOR_JWT_SECRET:dev-secret-change-me-…}
+  expiration-ms: ${JWT_EXPIRATION_MS:86400000}
+
+impaintor:
+  realtime:
+    jwt:
+      # Reapunto al mismo secret raíz — ambos firman/validan con la misma clave.
+      secret: ${jwt.secret}
+```
+
+### 7.2 `/ws` bloqueado por `SecurityFilterChain` de Track A
+
+**Síntoma:** Tests de integración WebSocket → `HTTP 403 did not permit the HTTP upgrade to WebSocket`.
+
+**Causa:** `SecurityConfig` de Track A tenía `anyRequest().authenticated()` que incluía `/ws`. Pero el handshake HTTP del WebSocket no debe pasar por filtros de auth porque el JWT se valida más tarde en el frame STOMP CONNECT (`JwtChannelInterceptor` de Track D).
+
+**Fix** en [SecurityConfig.java](../backend/src/main/java/com/impaintor/feature/auth/config/SecurityConfig.java):
+
+```java
+.authorizeHttpRequests(auth -> auth
+    .requestMatchers("/api/auth/**").permitAll()
+    // El handshake HTTP del WebSocket no pasa por filtros de auth — el JWT
+    // se valida en el frame STOMP CONNECT (ver Track D, JwtChannelInterceptor).
+    .requestMatchers("/ws/**").permitAll()
+    // … resto sin cambios …
+    .anyRequest().authenticated()
+)
+```
+
+Es un cambio en territorio de Track A que avisé al equipo en el commit message. Si Track A prefiere mover ese matcher a su propio archivo, perfecto — la lógica se mantiene.
+
+### 7.3 Stub `User.java` eliminado
+
+Track A trajo el `@Entity User` real con `@Builder`, `@PrePersist`, `@UniqueConstraint` y todos los campos de CLAUDE.md sec 4.1. Mi stub provisional ya no es necesario y se borró sin tocar nada del flujo (los nombres de campos coincidían exactamente, como anticipé en [§3.3](#3-stub-temporal-de-user-pending--track-a)).
+
+### 7.4 Lo que no he tocado
+
+- **`app.routes.server.ts`**: la versión del equipo (`'**'` → `Client`) cubre `/room/*` correctamente. Mi propuesta original era redundante.
+- **`package-lock.json`**: no lo subí en este commit. Debería committearse en algún momento por reproducibilidad del CI; lo dejo en discusión para no entrar en conflicto con la versión del equipo.
+
+### 7.5 Estado tras la reintegración
+
+| Componente | Estado | Notas |
+|---|---|---|
+| `./mvnw test` | ✅ 39/39 verdes | Track D + Track A (User, JwtService, SecurityConfig) + B + C |
+| `npm test` | ⚠️ 86/86 míos verdes; 2 rojos ajenos | `app.spec.ts` (scaffold heredado Track G/E) y `lobby.spec.ts` (Track F, falta provider de `ActivatedRoute`) |
+| `npm run build` | ✅ OK | Lazy chunk `game` = 40 kB. Warnings de tamaño CSS son de componentes E/F |
+
+Los 2 tests rojos del frontend NO son míos y existían antes de mi PR (uno por scaffold inicial, otro por un test mal configurado de Track F). Quedan como notas para los dueños.
+
+---
+
+## Apéndice — Cómo levantar todo localmente
+
+```bash
+# Backend
+cd backend
+./mvnw test                                        # 39 tests verdes
+./mvnw -DskipTests spring-boot:run                  # arranca en :8080 (necesita Postgres + RabbitMQ)
+
+# Stack completo (recomendado)
+docker-compose up --build                           # backend + db + rabbitmq
+
+# Frontend
+cd frontend
+npm install
+npm start                                           # ng serve en :4200
+# O en modo demo offline:
+# abrir http://localhost:4200/room/TEST/game?dev=true
+```

--- a/docs/track-i-plan.md
+++ b/docs/track-i-plan.md
@@ -1,0 +1,446 @@
+# Plan — Track I (P4 segunda responsabilidad, compartida con P3): Flujo del Juego (Frontend)
+
+## Contexto
+
+P4 tiene como segunda responsabilidad **Track I — Flujo del Juego** (Fase 2), compartida con P3 como pareja, con P5 dando soporte de testing y P6 cubriendo específicamente las tareas 2I.8 (UI flotante del impostor) y 2I.9 (SFX). Track I implementa la cara del juego en Angular: el `GameComponent` raíz que vive bajo `/room/:code/game` y que orquesta seis sub-vistas dirigidas por estado (dibujo, galería, votación, desempate, resultado, fin de partida) basándose en los eventos `GameEvent` que emite Track H por WebSocket sobre el `RealtimePublisher` de Track D.
+
+**Estado actual del codebase relevante:**
+- **Frontend** ([frontend/](frontend/)): Angular 21 standalone components, Vitest, Tailwind, SSR habilitado. Existe ya un `CanvasComponent` funcional bajo [frontend/src/app/features/game/components/canvas/](frontend/src/app/features/game/components/canvas/) con dibujo local 800×600, paleta, grosor, lápiz/goma. También [frontend/src/app/features/game/services/canvas.ts](frontend/src/app/features/game/services/canvas.ts) y [frontend/src/app/features/game/models/drawing.ts](frontend/src/app/features/game/models/drawing.ts) (con `DrawingStroke` que ya empareja con el `StrokeBroadcast` de Track D). Las rutas de [frontend/src/app/app.routes.ts](frontend/src/app/app.routes.ts) están vacías. **No hay `@stomp/stompjs`** instalado todavía. SSR catch-all en `RenderMode.Prerender`.
+- **Backend Track D** (mío, ya merged): emite todos los `GameEvent` definidos en sec 6.2 de CLAUDE.md a `/topic/room.{code}.game` con discriminador `type`, `RoleAssignment` privado a `/user/queue/private`. La forma JSON está fijada por los DTOs sealed records en [backend/src/main/java/com/impaintor/feature/realtime/dto/outbound/](backend/src/main/java/com/impaintor/feature/realtime/dto/outbound/).
+- **Backend Track H** (motor de juego): pendiente. Mientras no exista, no hay nadie emitiendo `GameEvent` reales.
+- **Frontend Track E** (auth/nav): pendiente. Tampoco hay JWT real en `localStorage` aún.
+- **Frontend Track F** (lobby + WebSocketService): pendiente. F va a proveer el wrapper Angular sobre `@stomp/stompjs`; mientras no exista, lo creamos nosotros y F lo absorberá en su merge.
+
+**Decisiones tomadas con el usuario:**
+1. **Stubs mínimos** — wrapper `@stomp/stompjs` propio + lectura directa de JWT de `localStorage` con la key acordada + `MockGameEventEmitter` dev-only para desarrollar las vistas sin Track H corriendo.
+2. **Client-only rendering para `/room/*`** — el resto del sitio puede prerenderizarse, pero las rutas con WebSocket no.
+3. **TDD estricto** con Vitest + TestBed: test → impl → refactor para cada componente y servicio.
+
+**Resultado esperado:** un usuario que entre a `/room/ABC123/game` (asumiendo JWT presente) ve la fase actual del juego, transita entre las seis vistas conforme al flujo de eventos de Track H, y participa (vota, reproduce dibujos en directo, ve resultados) sin que el cliente decida nunca el estado del juego — todo lo dirige el servidor.
+
+---
+
+## Mapa de propiedad de tareas
+
+| Tarea | Propietario | Estado |
+|---|---|---|
+| 2I.1 — Máquina de estados `GameComponent` | P3 + P4 | Track I (este plan) |
+| 2I.2 — `DrawingPhaseView` | P3 + P4 | Track I (este plan) |
+| 2I.3 — `GalleryView` | P3 + P4 | Track I (este plan) |
+| 2I.4 — `VotingView` | P3 + P4 | Track I (este plan) |
+| 2I.5 — `TieBreakView` | P3 + P4 | Track I (este plan) |
+| 2I.6 — `VoteResultView` | P3 + P4 | Track I (este plan) |
+| 2I.7 — `GameOverView` | P3 + P4 | Track I (este plan) |
+| 2I.8 — UI flotante impostor | **P6** | Plan integración (slot + signals expuestos) |
+| 2I.9 — SFX y feedback visual | **P6** | Plan integración (Subject<GameEvent>) |
+
+---
+
+## Vista arquitectónica
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│  Browser (Angular 21 standalone)                                │
+│                                                                  │
+│   ┌────────────────────────────────────────────────────────┐   │
+│   │  GameComponent (container, ruta /room/:code/game)       │   │
+│   │  ──────────────────────────────────────────────         │   │
+│   │  • Conecta StompClient con JWT del localStorage         │   │
+│   │  • Suscribe a /topic/room.{code}.game,                  │   │
+│   │             /topic/room.{code}.draw,                    │   │
+│   │             /user/queue/private                         │   │
+│   │  • Aplica cada GameEvent a GameStateService             │   │
+│   │  • Renderiza UNA sub-vista según phase()                │   │
+│   │  • Provee slot para ImpostorOverlay (P6)                │   │
+│   └────────────────────────────────────────────────────────┘   │
+│                              │                                   │
+│            ┌─────────────────┼─────────────────┐                 │
+│            ▼                 ▼                 ▼                 │
+│   ┌──────────────┐  ┌──────────────┐  ┌──────────────┐         │
+│   │ DrawingPhase │  │   Gallery    │  │   Voting     │  ...     │
+│   │     View     │  │     View     │  │     View     │         │
+│   └──────────────┘  └──────────────┘  └──────────────┘         │
+│                                                                  │
+└──────────────────────┬──────────────────────────────────────────┘
+                       │ ws (STOMP)
+                       ▼
+              backend Track D (ya hecho)
+                       │
+                       ▼
+              backend Track H (PENDIENTE)
+                  GameService
+                emite GameEvents
+```
+
+**Patrón:** "container + presentational components" + signals (Angular 21). El `GameComponent` es el único que tiene side-effects (suscripción WebSocket, aplicación de eventos al store). Las sub-vistas son presentacionales puras: reciben `GameState` por `@Input` y emiten acciones por `@Output`.
+
+---
+
+## Estructura de carpetas propuesta
+
+```
+frontend/src/app/
+├── features/
+│   ├── game/                                        ← Track I trabaja aquí
+│   │   ├── containers/
+│   │   │   └── game/
+│   │   │       ├── game.ts                          (2I.1)
+│   │   │       ├── game.html
+│   │   │       ├── game.css
+│   │   │       └── game.spec.ts
+│   │   ├── components/
+│   │   │   ├── canvas/                              ← YA EXISTE (Track G)
+│   │   │   ├── drawing-phase-view/                  (2I.2)
+│   │   │   ├── gallery-view/                        (2I.3)
+│   │   │   ├── voting-view/                         (2I.4)
+│   │   │   ├── tie-break-view/                      (2I.5)
+│   │   │   ├── vote-result-view/                    (2I.6)
+│   │   │   └── game-over-view/                      (2I.7)
+│   │   ├── models/
+│   │   │   ├── drawing.ts                           ← YA EXISTE
+│   │   │   ├── game-event.ts                        (NUEVO — discriminated union)
+│   │   │   ├── role-assignment.ts                   (NUEVO)
+│   │   │   └── game-state.ts                        (NUEVO)
+│   │   ├── services/
+│   │   │   ├── canvas.ts                            ← YA EXISTE
+│   │   │   ├── game-state.ts                        (NUEVO — store con signals)
+│   │   │   └── mock-game-event-emitter.ts           (NUEVO — dev-only)
+│   │   └── routes.ts                                (NUEVO — sub-routes lazy)
+│   └── realtime/                                    ← PENDING — Track F absorberá
+│       ├── services/
+│       │   ├── stomp-client.ts                      (wrapper @stomp/stompjs)
+│       │   └── stomp-client.spec.ts
+│       └── models/
+│           └── stomp.ts
+└── core/                                            ← (opcional) shared
+    └── auth/
+        └── token.ts                                 (PENDING — Track E lo reemplaza)
+```
+
+---
+
+## Modelos TypeScript clave
+
+### `game-event.ts` — discriminated union exhaustivo
+
+Espejo del `GameEvent` sealed interface backend ([backend GameEvent.java](backend/src/main/java/com/impaintor/feature/realtime/dto/outbound/GameEvent.java)). Strict types para que `switch` sea exhaustivo (`never` branch detecta fases nuevas en compilación):
+
+```typescript
+export type GameEvent =
+  | { type: 'GAME_START'; drawingOrder: number[]; round: number }
+  | { type: 'TURN_START'; playerId: number; timeSeconds: number }
+  | { type: 'TURN_END'; playerId: number }
+  | { type: 'GALLERY_PHASE' }
+  | { type: 'VOTE_PHASE'; timeSeconds: number }
+  | { type: 'VOTE_RESULT'; eliminated: number; wasImpostor: boolean; topVoted: TopVote[] }
+  | { type: 'VOTE_TIE'; tiedPlayers: TopVote[]; timeSeconds: number }
+  | { type: 'GUESS_ATTEMPT'; livesRemaining: number; correct: boolean }
+  | { type: 'NEW_ROUND'; round: number; drawingOrder: number[] }
+  | { type: 'GAME_OVER'; winner: 'PAINTERS' | 'IMPOSTOR'; reason: EndReason; impostorId: number; secretWord: string };
+
+export interface TopVote { id: number; votes: number }
+export type EndReason = 'VOTED_OUT' | 'WORD_GUESSED' | 'OUT_OF_LIVES' | 'TIE_NOT_BROKEN' | 'LAST_STANDING';
+```
+
+### `role-assignment.ts`
+
+```typescript
+export type RoleAssignment =
+  | { type: 'ROLE_ASSIGNMENT'; role: 'PAINTER'; word: string }
+  | { type: 'ROLE_ASSIGNMENT'; role: 'IMPOSTOR'; hint: string; lives: number };
+```
+
+### `game-state.ts` — slice tipado del store
+
+```typescript
+export type Phase = 'CONNECTING' | 'DRAWING' | 'GALLERY' | 'VOTING' | 'TIE_BREAK' | 'RESULT' | 'OVER';
+
+export interface GameState {
+  phase: Phase;
+  round: number;
+  drawingOrder: number[];
+  currentDrawerId: number | null;
+  timeRemainingSec: number;
+  myRole: 'PAINTER' | 'IMPOSTOR' | null;
+  secretWord: string | null;       // solo PAINTER
+  hint: string | null;              // solo IMPOSTOR
+  impostorLives: number | null;     // solo IMPOSTOR
+  canvases: Map<number, string>;    // playerId → dataURL del snapshot
+  myVote: number | null;
+  topVoted: TopVote[];
+  tiedPlayers: TopVote[];
+  eliminated: number | null;
+  wasImpostorEliminated: boolean | null;
+  gameOver: { winner: 'PAINTERS' | 'IMPOSTOR'; reason: EndReason; impostorId: number; secretWord: string } | null;
+}
+```
+
+---
+
+## `GameStateService` — store con signals
+
+Servicio `providedIn: 'root'` (singleton por sesión, se resetea al entrar/salir de una sala). API:
+
+- `state: Signal<GameState>` (readonly)
+- Selectores derivados via `computed()`: `phase()`, `currentDrawerId()`, `isMyTurn()`, `isImpostor()`, `hint()`, `impostorLives()`
+- `applyEvent(event: GameEvent): void` — switch exhaustivo que muta el state según el tipo de evento
+- `applyRoleAssignment(role: RoleAssignment): void`
+- `applyStrokeBroadcast(stroke: StrokeBroadcast): void` (forwarding al `CanvasService` para que renderice en el canvas espectador)
+- `gameEvents$: Subject<GameEvent>` — para que P6 enganche su `AudioService` (2I.9)
+- `reset()` — al desconectar
+
+Cada handler de evento se testea unitariamente con TDD: dado un `GameState` inicial + un `GameEvent` X, asertar el `GameState` resultante.
+
+---
+
+## `StompClientService` — wrapper `@stomp/stompjs`
+
+**PENDING — Track F va a absorber/reemplazar este servicio.** Mientras tanto:
+
+- Métodos: `connect(jwt: string): Observable<ConnectionStatus>`, `disconnect()`, `subscribe<T>(destination: string): Observable<T>`, `send<T>(destination: string, body: T): void`
+- Auto-reconnect con backoff (5 reintentos, delay creciente)
+- Logging dev-only (`environment.dev`)
+- Solo se inicializa si `isPlatformBrowser(this.platformId)` (compatibilidad SSR aunque en este proyecto las rutas /room/* sean client-only)
+- Tests con `@stomp/stompjs` mock-eado vía Vitest `vi.mock`
+
+---
+
+## `MockGameEventEmitter` — dev-only
+
+Servicio activable mediante query-param `?dev=true` o flag `environment.dev`. Expone un script de eventos secuencial que simula una partida completa: GAME_START → TURN_START × N → TURN_END × N → GALLERY_PHASE → VOTE_PHASE → VOTE_RESULT → NEW_ROUND → ... → GAME_OVER. También un panel UI dev (oculto en prod) con botones para disparar cada `GameEvent` manualmente. Permite:
+
+1. Desarrollar las 6 sub-vistas sin que Track H exista.
+2. Que P5 escriba tests de integración del flujo sin levantar backend.
+3. Demo offline para presentaciones intermedias.
+
+---
+
+## Plan de implementación TDD por fases
+
+### Fase 1 — Foundation (independiente de upstream)
+
+1. `npm install --save @stomp/stompjs sockjs-client` y `npm install --save-dev @types/sockjs-client`.
+2. Crear `proxy.conf.json` para que `ng serve` reenvíe `/api` y `/ws` a `localhost:8080`.
+3. Modelos: `game-event.ts`, `role-assignment.ts`, `game-state.ts` (sin tests — son tipos puros).
+4. **TDD `GameStateService`**: escribir 11 tests (uno por handler de GameEvent + roleAssignment + reset) → implementar.
+5. **TDD `StompClientService`**: tests con mock de `@stomp/stompjs` (connect / subscribe / send / reconnect) → implementar.
+6. `MockGameEventEmitter` (dev-only, sin TDD — es scaffolding).
+
+### Fase 2 — Container `GameComponent` (2I.1)
+
+7. Añadir ruta lazy `{ path: 'room/:code/game', loadComponent: () => import('./features/game/containers/game/game').then(m => m.GameComponent) }` a [frontend/src/app/app.routes.ts](frontend/src/app/app.routes.ts).
+8. En [frontend/src/app/app.routes.server.ts](frontend/src/app/app.routes.server.ts) añadir entry `{ path: 'room/**', renderMode: RenderMode.Client }` antes del catch-all prerender.
+9. **TDD `GameComponent`**: tests con TestBed y `MockGameEventEmitter` inyectado en lugar de `StompClientService`. Casos:
+   - `phase` inicial = `CONNECTING`, render `<div>Connecting…</div>`.
+   - Tras `GAME_START` → `phase` = `DRAWING`, renderiza `<app-drawing-phase-view>`.
+   - Tras `GALLERY_PHASE` → `<app-gallery-view>`.
+   - Tras `VOTE_PHASE` → `<app-voting-view>`.
+   - Tras `VOTE_TIE` → `<app-tie-break-view>`.
+   - Tras `VOTE_RESULT` → `<app-vote-result-view>`.
+   - Tras `GAME_OVER` → `<app-game-over-view>`.
+   - Al destruir el componente → `StompClientService.disconnect()` invocado.
+
+### Fase 3 — Sub-vistas (2I.2 → 2I.7)
+
+Para cada componente, mismo ciclo TDD: spec con TestBed + `@Input()` mockeado + assertions de DOM render + `@Output()` emit.
+
+| # | Componente | Inputs principales | Outputs | Test fundamentales |
+|---|---|---|---|---|
+| 2I.2 | `DrawingPhaseView` | `state: GameState`, `playerId: number` | `stroke`, `clear` | renderiza word si PAINTER, renderiza hint si IMPOSTOR, canvas activo si `isMyTurn`, modo espectador si no, timer countdown |
+| 2I.3 | `GalleryView` | `state: GameState` | (ninguno — auto-transición servidor) | renderiza grid de N canvas snapshots, muestra timer hasta votación |
+| 2I.4 | `VotingView` | `state: GameState` | `vote(playerId)` | renderiza tarjetas por jugador vivo con miniatura, click selecciona voto, timer, deshabilita doble-voto |
+| 2I.5 | `TieBreakView` | `state: GameState` | `moveVote(playerId)` | resalta `tiedPlayers`, solo IMPOSTOR ve botón "mover voto", timer countdown |
+| 2I.6 | `VoteResultView` | `state: GameState` | (ninguno) | muestra eliminado, revela `wasImpostor`, transición auto |
+| 2I.7 | `GameOverView` | `state: GameState` | `playAgain` | revela palabra, hint, impostor, ronda final, botón |
+
+### Fase 4 — Integración con P6 (slots/hooks)
+
+Track I no implementa 2I.8 ni 2I.9, pero sí prepara los puntos de enganche para que P6 conecte sin fricción:
+
+- En `game.html`, añadir `<ng-content select="[impostorOverlay]"></ng-content>` debajo del `router-outlet` de la sub-vista. P6 inyectará su componente flotante ahí, condicional a `gameState.isImpostor()`.
+- `GameStateService` expone como API pública: `isImpostor()`, `hint()`, `impostorLives()`, `gameEvents$` (Subject de eventos para SFX). Documentar el contrato en JSDoc.
+- Crear `ImpostorOverlaySlot` directiva placeholder con `// PENDING — P6 reemplaza` para que el GameComponent compile en el ínterin.
+
+### Fase 5 — Verificación end-to-end
+
+1. `ng test` → todos verdes (cobertura objetivo ≥80% en `services/` y `containers/`).
+2. `ng serve` + `?dev=true` → `MockGameEventEmitter` ejecuta script completo de partida y se ven las seis vistas en secuencia sin errores en consola.
+3. `ng build` → bundle producción compila sin warnings de SSR.
+4. **Smoke test integrado** (cuando Track H esté disponible):
+   - Levantar backend con `docker-compose up`.
+   - Abrir 3 pestañas Angular como `/room/TEST/game` con tokens distintos.
+   - Crear sala vía REST (Track B), iniciar partida, observar que las tres pestañas reciben `GAME_START` y arrancan flujo.
+
+---
+
+## Dependencias cruzadas (SPI / contratos PENDING)
+
+| Pieza | Dueño | Estado mientras tanto |
+|---|---|---|
+| `StompClientService` | Track F (Lobby + WS) | Stub propio bajo `features/realtime/`, F lo absorbe en su PR |
+| `AuthService.getToken()` | Track E (Auth/Nav) | Helper directo `localStorage.getItem('jwt')` con TODO comment; E proveerá `AuthService` oficial. Documentar la **key acordada `'jwt'`** en CLAUDE.md después |
+| `RouterGuard` (auth + sala válida) | Track E | Sin guard ahora; E añade después |
+| `GameService` backend (emisor de eventos) | Track H | `MockGameEventEmitter` dev-only cubre desarrollo offline |
+| `RoomService.getRoom(code)` REST | Track B | Innecesario para Track I — todos los datos llegan por WebSocket tras el `GAME_START` |
+| `ImpostorOverlay` componente | **P6** | `<ng-content select="[impostorOverlay]">` slot + signals expuestos en `GameStateService` |
+| `AudioService` SFX | **P6** | `gameEvents$: Subject<GameEvent>` en `GameStateService`; P6 se subscribe |
+
+---
+
+## Riesgos y mitigaciones
+
+| Riesgo | Mitigación |
+|---|---|
+| Track H emite eventos con forma JSON ligeramente distinta a la spec | Generar typeguards a partir de los DTOs de Track D (yo soy P4, conozco la forma exacta — los espejo en `game-event.ts`). En CI añadir un test de contrato que compare contra fixture JSON sacada del repo backend. |
+| `@stomp/stompjs` o WebSocket roto en SSR | Por eso /room/* es **Client-only**. Además, `StompClientService.connect()` arranca con `if (!isPlatformBrowser) return EMPTY`. |
+| Vitest + TestBed compatibility en Angular 21 | Validar primero con un test trivial de `GameComponent` antes de escribir suite completa; si rompe, ajustar config en `angular.json` (target unit-test). |
+| Strict TypeScript discriminated union no exhaustivo | Cada `switch (event.type)` termina en `default: const _exhaustive: never = event;` para que el compilador detecte fases nuevas. |
+| Estado de canvas remoto se desincroniza con `StrokeBroadcast` perdidos | A futuro implementar replay/buffer de strokes. Por ahora aceptamos pérdida si la red corta — Track H puede reenviar snapshots si llega esa necesidad. |
+| Conflicto de merge cuando F mergee su `WebSocketService` | Aislamos nuestro `StompClientService` en `features/realtime/`. F coge ese archivo como base y lo refina; si renombra, sustituimos imports con un find/replace. |
+| 2I.8 (P6) no llega a tiempo | El IMPOSTOR igual puede jugar — la `DrawingPhaseView` tiene un fallback inline `<input>` para el guess si P6 no provee overlay (marcado `// PENDING — P6 floating overlay`). |
+
+---
+
+## Archivos críticos a crear / modificar
+
+**Crear:**
+- [frontend/src/app/features/realtime/services/stomp-client.ts](frontend/src/app/features/realtime/services/stomp-client.ts) + spec
+- [frontend/src/app/features/realtime/models/stomp.ts](frontend/src/app/features/realtime/models/stomp.ts)
+- [frontend/src/app/features/game/models/game-event.ts](frontend/src/app/features/game/models/game-event.ts)
+- [frontend/src/app/features/game/models/role-assignment.ts](frontend/src/app/features/game/models/role-assignment.ts)
+- [frontend/src/app/features/game/models/game-state.ts](frontend/src/app/features/game/models/game-state.ts)
+- [frontend/src/app/features/game/services/game-state.ts](frontend/src/app/features/game/services/game-state.ts) + spec
+- [frontend/src/app/features/game/services/mock-game-event-emitter.ts](frontend/src/app/features/game/services/mock-game-event-emitter.ts)
+- [frontend/src/app/features/game/containers/game/game.ts](frontend/src/app/features/game/containers/game/game.ts) + html + css + spec
+- [frontend/src/app/features/game/components/drawing-phase-view/](frontend/src/app/features/game/components/drawing-phase-view/) (4 archivos: ts/html/css/spec)
+- [frontend/src/app/features/game/components/gallery-view/](frontend/src/app/features/game/components/gallery-view/) (idem)
+- [frontend/src/app/features/game/components/voting-view/](frontend/src/app/features/game/components/voting-view/) (idem)
+- [frontend/src/app/features/game/components/tie-break-view/](frontend/src/app/features/game/components/tie-break-view/) (idem)
+- [frontend/src/app/features/game/components/vote-result-view/](frontend/src/app/features/game/components/vote-result-view/) (idem)
+- [frontend/src/app/features/game/components/game-over-view/](frontend/src/app/features/game/components/game-over-view/) (idem)
+- [frontend/src/app/core/auth/token.ts](frontend/src/app/core/auth/token.ts) (helper localStorage, PENDING — Track E reemplaza)
+- [frontend/proxy.conf.json](frontend/proxy.conf.json)
+
+**Modificar:**
+- [frontend/package.json](frontend/package.json) — añadir `@stomp/stompjs` y `sockjs-client` + types
+- [frontend/src/app/app.routes.ts](frontend/src/app/app.routes.ts) — ruta lazy `/room/:code/game`
+- [frontend/src/app/app.routes.server.ts](frontend/src/app/app.routes.server.ts) — Client-only para `/room/**`
+- [frontend/angular.json](frontend/angular.json) — añadir `proxyConfig` al target `serve`
+
+---
+
+## Criterios de finalización
+
+1. `npm test` → todos verdes (≥80% cobertura en `services/` y `containers/game/`).
+2. `npm run build` → producción sin errores ni warnings.
+3. `ng serve` con `?dev=true` reproduce flujo completo del juego en las seis vistas.
+4. `GameStateService` con switch exhaustivo sobre `GameEvent` (compilador valida).
+5. Cuando Track F merge: solo cambia el import de `StompClientService` en `GameComponent`, ni un test se rompe.
+6. Cuando Track H merge: quitamos `?dev=true` del flujo de demo y la conexión real fluye.
+7. Cuando P6 termine 2I.8/2I.9: enchufan en el slot `[impostorOverlay]` y se subscriben a `gameEvents$` sin tocar `GameComponent`.
+
+---
+
+## 4. Decisiones técnicas del plan de Track I
+
+Plan completo en [docs/track-i-plan.md](./track-i-plan.md). Resumen de decisiones tomadas:
+
+### 4.1 Stubs upstream — nivel **mínimo**
+
+- Creamos un `StompClientService` propio bajo `features/realtime/` que envuelve `@stomp/stompjs`. **PENDING — Track F absorberá** este servicio cuando llegue.
+- Para JWT leemos `localStorage.getItem('jwt')` con un helper en `core/auth/token.ts`. **PENDING — Track E** proveerá `AuthService` oficial. La key acordada es `'jwt'`.
+- Para desarrollo offline (sin Track H), creamos `MockGameEventEmitter` activable con `?dev=true` que dispara la secuencia completa de un partido. Cuando Track H exista, se desactiva el flag y la conexión real fluye.
+
+### 4.2 SSR — Client-only para `/room/*`
+
+- `app.routes.server.ts` añade `{ path: 'room/**', renderMode: RenderMode.Client }` antes del catch-all prerender.
+- Razón: las rutas de juego usan WebSocket y JWT en `localStorage`, ninguno disponible en el servidor SSR. El resto del sitio (login, leaderboard, home) puede prerenderizarse normalmente.
+
+### 4.3 TDD estricto con Vitest
+
+- Mismo enfoque que en Track D. Cada componente y servicio: spec con TestBed, expectativas, después implementación, finalmente refactor.
+- Cobertura objetivo ≥80% en `services/` y `containers/`.
+
+### 4.4 Patrón container + presentational + signals
+
+- `GameComponent` (container) es el ÚNICO con efectos secundarios: subscripción WebSocket, aplicación de eventos al store. Vive en `containers/game/`.
+- Las seis sub-vistas son presentacionales puras: reciben `GameState` por `@Input` y emiten acciones por `@Output`. Viven en `components/*-view/`.
+- `GameStateService` es un store con signals (Angular 21). Cada `GameEvent` se aplica vía `applyEvent()` con `switch` exhaustivo (TypeScript `never` branch detecta fases nuevas en compilación).
+
+### 4.5 División P3 / P4 sugerida (negociar entre nosotros)
+
+| Tarea | Sugerencia | Estado |
+|---|---|---|
+| 2I.1 — Container + state machine | P4 ya lo hizo en sesión solo | ✅ Hecho (ver [p4-log.md sec 4](./p4-log.md#4-track-i-fase-1--2--foundation--container-entregado-2026-05-06)) |
+| `MockGameEventEmitter` + `GameStateService` + `StompClientService` + `SpectatorCanvasService` | P4 | ✅ Hecho |
+| 2I.2 — `DrawingPhaseView` | P4 (conozco el formato `StrokeBroadcast` de Track D) | ✅ Hecho (ver [p4-log.md sec 5](./p4-log.md#5-track-i--vistas-p4--cierre-46-entregado-2026-05-06)) |
+| 2I.3 — `GalleryView` | P3 | 🟡 Placeholder, falta vista real |
+| 2I.4 — `VotingView` | P4 | ✅ Hecho |
+| 2I.5 — `TieBreakView` | P3 | 🟡 Placeholder, falta vista real |
+| 2I.6 — `VoteResultView` | P3 | 🟡 Placeholder, falta vista real |
+| 2I.7 — `GameOverView` | P4 | ✅ Hecho |
+| 2I.8 — UI flotante impostor | **P6** (no nosotros) | Slot listo en `game.html`. Fallback inline activo en `DrawingPhaseView` mientras tanto |
+| 2I.9 — SFX y feedback | **P6** (no nosotros) | `gameEvents$` listo en `GameStateService` |
+
+> Es una propuesta. Si prefieres otro reparto, lo hablamos.
+
+### 4.6 Decisión cerrada — populación de `state.canvases` vía `SpectatorCanvasService` (Opción B)
+
+> **Estado:** ✅ Decidido por P4 (autonomía concedida por el usuario). Reversible si P3 lo discute al pair-program.
+> **Implementado:** sí, ver `frontend/src/app/features/game/services/spectator-canvas.ts`.
+
+**Problema.** `GameState.canvases: Map<number, string>` estaba declarado en el modelo pero `GameStateService` no lo poblaba. `VotingView` (P4) y `GalleryView` (P3) necesitan miniaturas de los dibujos de la ronda.
+
+**Opciones consideradas:**
+
+- **Opción A** — `GameStateService` lo gestiona internamente. Centralizado pero **acopla el servicio al DOM** (`HTMLCanvasElement`/`OffscreenCanvas`), rompe los 18 tests existentes (jsdom no implementa Canvas API completa) y mezcla concerns (estado de fase del juego ≠ replay de strokes).
+- **Opción B (elegida)** — Servicio nuevo `SpectatorCanvasService` aparte, se subscribe a `gameStateService.gameEvents$` y a un input de strokes, mantiene canvas off-screen por jugador y expone `snapshots: Signal<Record<id, dataUrl>>`.
+- **Opción C** — Cada vista que muestra miniaturas gestiona sus propios canvas internos. Duplicación entre `GalleryView` y `VotingView`, posible inconsistencia si ambas se muestran simultáneamente, y N×M canvases en RAM en el peor caso.
+
+**Por qué Opción B:**
+
+1. **`GameStateService` queda puro.** Solo maneja `GameEvent`/`RoleAssignment`, no toca DOM. Los 18 tests existentes no cambian.
+2. **Single responsibility.** El replay de strokes es un concern distinto del state machine de fases. Un servicio por concern, cada uno testeable en aislamiento.
+3. **Reutilizable.** `DrawingPhaseView` (modo espectador), `VotingView` y `GalleryView` consumen la misma fuente. P6 podría usarla también si decide mostrar previsualización en el `ImpostorOverlay`.
+4. **Estable frente a Track G/F.** Su contrato es `replayStroke(s) / clearPlayer(id) / snapshots(): Signal<Record<id,dataUrl>>` — invariante aunque cambien internals del Canvas o del WebSocket.
+5. **SSR-safe.** Si `!isPlatformBrowser`, todos los métodos son no-op.
+
+**Notas de implementación.**
+
+- El servicio mantiene `HTMLCanvasElement` off-screen (no insertados en DOM, vía `document.createElement('canvas')`) en un `Map<playerId, HTMLCanvasElement>`, lazy-creados al recibir el primer stroke de un jugador.
+- En cada stroke: dibuja en el canvas correspondiente y actualiza el signal `snapshots` con el nuevo `toDataURL('image/png')`. Es un pequeño coste de perf por stroke (≤8 jugadores × ≤30 strokes/min) pero simplifica el binding (`<img [src]="snapshots()[id]">`) en las vistas.
+- Reset automático: el servicio se subscribe a `gameStateService.gameEvents$` y limpia todos los canvases al recibir `GAME_START` o `NEW_ROUND`.
+- `GameComponent` se subscribe a `/topic/room.{code}.draw` y forwards los `StrokeBroadcast`/`ClearCanvasBroadcast` al servicio.
+- En modo `?dev=true`, los snapshots quedan vacíos porque el `MockGameEventEmitter` no simula strokes — aceptable para demo de fases, marcado en doc del servicio.
+
+**Reversibilidad.** Si P3 al pair-program prefiere otra opción, los cambios están aislados a un único archivo (`spectator-canvas.ts` + spec) y al wiring en `GameComponent`. Migrar a A o C es cuestión de mover ese código.
+
+---
+
+## 5. Coordinación cruzada con otros tracks
+
+Lista de acciones que activan/desactivan piezas de Track I cuando los demás tracks merge:
+
+- **Track A merge** → borrar `feature/user/models/User.java` (stub) y verificar que la `User` de Track A respeta los campos `id`, `email`, `username`, `password`, `elo`, `gamesPlayed`, `gamesWon`, `createdAt`. Si no, ajustar `Room.java`/`RoomController.java` (Track B).
+- **Track A merge** → confirmar que su `JwtTokenProvider` o equivalente firma con el secret de `impaintor.realtime.jwt.secret`. Si Track A trae su propio secret, unificar en `application.yml`.
+- **Track A merge** → su `SecurityFilterChain` real desactivará `RealtimeSecurityConfig` automáticamente vía `@ConditionalOnMissingBean(SecurityFilterChain.class)`.
+- **Track B merge** → su impl de `RoomMembershipChecker` desactivará `AlwaysAllowMembershipChecker` automáticamente vía `@ConditionalOnMissingBean(RoomMembershipChecker.class)`.
+- **Track B merge** → asegurar que `RoomService.create()` invoque `RoomTopicRegistry.registerRoom(code)` y `RoomService.delete()` invoque `unregisterRoom(code)`.
+- **Track H merge** → su `GameService` (o equivalente) implementará `GameInputHandler` y desactivará `LoggingGameInputHandler` vía `@ConditionalOnMissingBean(GameInputHandler.class)`. También inyectará `RealtimePublisher` para emitir eventos.
+- **Track E merge (frontend)** → su `AuthService` reemplazará el helper directo `frontend/src/app/core/auth/token.ts`. Buscar imports de `getStoredToken` y migrar a `AuthService.getToken()`.
+- **Track F merge (frontend)** → su `WebSocketService` reemplazará nuestro `StompClientService` bajo `features/realtime/`. Cambiar imports en `GameComponent`.
+- **P6 trabaja en 2I.8 / 2I.9** → enchufa su `ImpostorOverlay` en el slot `[impostorOverlay]` y subscribe `AudioService` a `GameStateService.gameEvents$`. Sin tocar nuestros componentes.
+
+---
+
+## 6. Cómo sustituir un placeholder por una vista real (recipe TDD)
+
+Aplica a las 6 sub-vistas (2I.2 → 2I.7). Suponiendo que se quiere implementar `GalleryView`:
+
+1. Abrir `frontend/src/app/features/game/components/gallery-view/gallery-view.spec.ts`.
+2. Borrar el test placeholder y escribir los tests TDD reales (cuadrícula con N items, transición por timer, etc.).
+3. Reemplazar la implementación en `gallery-view.{ts,html,css}`. El `state: GameState` ya está disponible como `@Input` y contiene todo lo necesario (`canvases`, `drawingOrder`, `timeRemainingSec`, …).
+4. **Ningún otro archivo necesita tocarse** — el container ya enchufa el componente correctamente vía `@switch`.
+5. `npm test` valida que los tests del container siguen verdes (solo dependen del selector `[data-testid="gallery-phase"]`, así que mantén ese atributo en el wrapper raíz del HTML real).
+
+Si la vista necesita emitir acciones al servidor (voto, mover voto, jugar otra vez, stroke), añadir un `@Output` al componente y conectar el handler en `game.html` mediante `(voteCast)="onVoteCast($event)"`. El método nuevo en `GameComponent` invoca `this.stomp.send(...)`.

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -64,6 +64,9 @@
         },
         "serve": {
           "builder": "@angular/build:dev-server",
+          "options": {
+            "proxyConfig": "proxy.conf.json"
+          },
           "configurations": {
             "production": {
               "buildTarget": "frontend:build:production"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,9 +32,11 @@
     "@tailwindcss/postcss": "^4.1.12",
     "@types/express": "^5.0.1",
     "@types/node": "^20.17.19",
+    "@types/sockjs-client": "^1.5.4",
     "jsdom": "^28.0.0",
     "postcss": "^8.5.3",
     "prettier": "^3.8.1",
+    "sockjs-client": "^1.6.1",
     "tailwindcss": "^4.1.12",
     "typescript": "~5.9.2",
     "vitest": "^4.0.8"

--- a/frontend/proxy.conf.json
+++ b/frontend/proxy.conf.json
@@ -1,0 +1,15 @@
+{
+  "/api": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "debug"
+  },
+  "/ws": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true,
+    "ws": true,
+    "logLevel": "debug"
+  }
+}

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -22,6 +22,11 @@ export const routes: Routes = [
   // Game & Room Routes
   { path: 'room/create', component: CreateRoomComponent },
   { path: 'room/:code/lobby', component: Lobby },
+  {
+    path: 'room/:code/game',
+    loadComponent: () =>
+      import('./features/game/containers/game/game').then((m) => m.GameComponent),
+  },
   
   // Fallback
   { path: '**', redirectTo: '' }

--- a/frontend/src/app/core/auth/token.ts
+++ b/frontend/src/app/core/auth/token.ts
@@ -1,0 +1,18 @@
+// PENDING — Track E (Auth) reemplazará este helper con AuthService.getToken().
+// Mientras tanto, leemos directamente de localStorage con la key acordada 'jwt'.
+
+import { isPlatformBrowser } from '@angular/common';
+import { PLATFORM_ID, inject } from '@angular/core';
+
+const TOKEN_KEY = 'jwt';
+
+/** Devuelve el JWT crudo si existe en localStorage, o null. SSR-safe. */
+export function getStoredToken(): string | null {
+  const platformId = inject(PLATFORM_ID);
+  if (!isPlatformBrowser(platformId)) return null;
+  try {
+    return window.localStorage.getItem(TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/app/features/game/components/drawing-phase-view/drawing-phase-view.css
+++ b/frontend/src/app/features/game/components/drawing-phase-view/drawing-phase-view.css
@@ -1,0 +1,122 @@
+.drawing-phase {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
+  padding: 1.25rem;
+}
+
+.phase-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.phase-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #333;
+}
+
+.timer {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  background: #2563eb;
+  color: white;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.875rem;
+}
+
+.word-banner.painter {
+  background: #ecfdf5;
+  border: 1px solid #10b981;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  margin-bottom: 1rem;
+  font-size: 1.05rem;
+}
+
+.hint-banner.impostor {
+  background: #fef3c7;
+  border: 1px solid #f59e0b;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  margin-bottom: 1rem;
+  display: flex;
+  gap: 1.5rem;
+  justify-content: space-between;
+}
+
+.canvas-area {
+  margin: 1rem 0;
+  min-height: 400px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.canvas-area .hint {
+  text-align: center;
+  color: #666;
+  margin-bottom: 0.5rem;
+}
+
+.waiting,
+.empty-canvas {
+  padding: 4rem;
+  text-align: center;
+  color: #999;
+  border: 2px dashed #ddd;
+  border-radius: 8px;
+  background: #fafafa;
+  width: 100%;
+}
+
+.spectator-img {
+  max-width: 100%;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: #fff;
+}
+
+.impostor-guess-box {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  background: #f5f3ff;
+  border: 1px solid #8b5cf6;
+  border-radius: 6px;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.impostor-guess-box label {
+  font-weight: 600;
+  color: #5b21b6;
+}
+
+.impostor-guess-box input {
+  flex: 1;
+  min-width: 200px;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #c4b5fd;
+  border-radius: 4px;
+  font-size: 0.95rem;
+}
+
+.impostor-guess-box button {
+  padding: 0.4rem 1rem;
+  background: #8b5cf6;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.impostor-guess-box button:disabled {
+  background: #c4b5fd;
+  cursor: not-allowed;
+}

--- a/frontend/src/app/features/game/components/drawing-phase-view/drawing-phase-view.html
+++ b/frontend/src/app/features/game/components/drawing-phase-view/drawing-phase-view.html
@@ -1,0 +1,60 @@
+<div class="drawing-phase" data-testid="drawing-phase">
+  <header class="phase-header">
+    <h2>Fase de dibujo — Ronda {{ state.round }}</h2>
+    <div class="timer" data-testid="timer">⏱ {{ state.timeRemainingSec }}s</div>
+  </header>
+
+  @if (state.myRole === 'PAINTER') {
+    <div class="word-banner painter" data-testid="painter-word">
+      Tu palabra: <strong>{{ state.secretWord }}</strong>
+    </div>
+  }
+
+  @if (isImpostor()) {
+    <div class="hint-banner impostor">
+      <span data-testid="impostor-hint">Pista: <strong>{{ state.hint }}</strong></span>
+      <span data-testid="impostor-lives">Vidas: <strong>{{ state.impostorLives }}</strong></span>
+    </div>
+  }
+
+  <main class="canvas-area">
+    @if (state.currentDrawerId === null) {
+      <div class="waiting" data-testid="waiting-for-turn">
+        <p>Esperando al siguiente jugador…</p>
+      </div>
+    } @else if (canDraw()) {
+      <div data-testid="active-canvas">
+        <p class="hint">Es tu turno. Dibuja la palabra.</p>
+        <app-canvas [isActive]="true" [showWord]="state.secretWord ?? ''" />
+      </div>
+    } @else {
+      <div class="spectator" data-testid="spectator-view">
+        <p class="hint">{{ state.currentDrawerId }} está dibujando…</p>
+        @if (drawerSnapshot()) {
+          <img [src]="drawerSnapshot()" alt="Dibujo en directo" class="spectator-img" />
+        } @else {
+          <div class="empty-canvas">(aún no hay trazos)</div>
+        }
+      </div>
+    }
+  </main>
+
+  @if (isImpostor()) {
+    <!-- PENDING — P6 entregará 2I.8 (UI flotante). Este bloque inline es un fallback. -->
+    <aside class="impostor-guess-box" data-testid="impostor-guess-box">
+      <label for="guess-input">Intento de adivinación:</label>
+      <input
+        id="guess-input"
+        data-testid="impostor-guess-input"
+        type="text"
+        placeholder="¿cuál es la palabra?"
+        [value]="guessText()"
+        (input)="onGuessInput($event)"
+        (keydown.enter)="submitGuess()"
+      />
+      <button data-testid="impostor-guess-submit" (click)="submitGuess()" [disabled]="!guessText().trim()">
+        Enviar
+      </button>
+    </aside>
+  }
+</div>

--- a/frontend/src/app/features/game/components/drawing-phase-view/drawing-phase-view.spec.ts
+++ b/frontend/src/app/features/game/components/drawing-phase-view/drawing-phase-view.spec.ts
@@ -1,0 +1,298 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { DrawingPhaseView } from './drawing-phase-view';
+import { GameState, INITIAL_STATE } from '../../models/game-state';
+import { SpectatorCanvasService } from '../../services/spectator-canvas';
+
+// Stub mínimo del CanvasService para que el CanvasComponent no rompa al inicializar.
+// El servicio existe en features/game/services/canvas.ts y CanvasComponent lo inyecta.
+
+function stateForPainter(currentDrawerId: number | null = null): GameState {
+  return {
+    ...INITIAL_STATE,
+    phase: 'DRAWING',
+    round: 1,
+    drawingOrder: [42, 7],
+    currentDrawerId,
+    timeRemainingSec: 30,
+    myRole: 'PAINTER',
+    secretWord: 'guitarra',
+  };
+}
+
+function stateForImpostor(currentDrawerId: number | null = null): GameState {
+  return {
+    ...INITIAL_STATE,
+    phase: 'DRAWING',
+    round: 1,
+    drawingOrder: [42, 7],
+    currentDrawerId,
+    timeRemainingSec: 30,
+    myRole: 'IMPOSTOR',
+    hint: 'piano',
+    impostorLives: 1,
+  };
+}
+
+describe('DrawingPhaseView', () => {
+  beforeEach(() => {
+    // Mock de Canvas API para que CanvasComponent (importado por DrawingPhaseView
+    // cuando es mi turno) no rompa en jsdom.
+    const ctxStub = {
+      fillStyle: '',
+      strokeStyle: '',
+      lineCap: '',
+      lineJoin: '',
+      lineWidth: 0,
+      fillRect: vi.fn(),
+      beginPath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      stroke: vi.fn(),
+      clearRect: vi.fn(),
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      ctxStub as unknown as CanvasRenderingContext2D,
+    );
+    vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockReturnValue('data:image/png;base64,FAKE');
+
+    TestBed.configureTestingModule({
+      imports: [DrawingPhaseView],
+      providers: [
+        // Stub del SpectatorCanvasService para no depender de Canvas API en jsdom.
+        {
+          provide: SpectatorCanvasService,
+          useValue: {
+            snapshots: () => ({}),
+            replayStroke: vi.fn(),
+            clearPlayer: vi.fn(),
+            replayBroadcast: vi.fn(),
+          },
+        },
+      ],
+    });
+  });
+
+  it('PAINTER ve la palabra secreta', () => {
+    const fixture = TestBed.createComponent(DrawingPhaseView);
+    fixture.componentRef.setInput('state', stateForPainter(42));
+    fixture.componentRef.setInput('myPlayerId', 7);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.querySelector('[data-testid="painter-word"]')?.textContent).toContain('guitarra');
+    expect(root.querySelector('[data-testid="impostor-hint"]')).toBeNull();
+  });
+
+  it('IMPOSTOR ve la pista y las vidas, no la palabra', () => {
+    const fixture = TestBed.createComponent(DrawingPhaseView);
+    fixture.componentRef.setInput('state', stateForImpostor(42));
+    fixture.componentRef.setInput('myPlayerId', 7);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.querySelector('[data-testid="impostor-hint"]')?.textContent).toContain('piano');
+    expect(root.querySelector('[data-testid="impostor-lives"]')?.textContent).toContain('1');
+    expect(root.querySelector('[data-testid="painter-word"]')).toBeNull();
+  });
+
+  it('cuando es mi turno (PAINTER) muestra canvas activo', () => {
+    const fixture = TestBed.createComponent(DrawingPhaseView);
+    fixture.componentRef.setInput('state', stateForPainter(42));
+    fixture.componentRef.setInput('myPlayerId', 42);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.querySelector('[data-testid="active-canvas"]')).toBeTruthy();
+    expect(root.querySelector('[data-testid="spectator-view"]')).toBeNull();
+  });
+
+  it('cuando NO es mi turno muestra modo espectador con miniatura del dibujante', () => {
+    const fixture = TestBed.createComponent(DrawingPhaseView);
+    fixture.componentRef.setInput('state', stateForPainter(42));
+    fixture.componentRef.setInput('myPlayerId', 7);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.querySelector('[data-testid="spectator-view"]')).toBeTruthy();
+    expect(root.querySelector('[data-testid="active-canvas"]')).toBeNull();
+  });
+
+  it('IMPOSTOR no puede dibujar nunca, siempre ve modo espectador', () => {
+    const fixture = TestBed.createComponent(DrawingPhaseView);
+    fixture.componentRef.setInput('state', stateForImpostor(42));
+    fixture.componentRef.setInput('myPlayerId', 7);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.querySelector('[data-testid="spectator-view"]')).toBeTruthy();
+    expect(root.querySelector('[data-testid="active-canvas"]')).toBeNull();
+  });
+
+  it('IMPOSTOR ve la caja de adivinación inline (fallback hasta 2I.8 de P6)', () => {
+    const fixture = TestBed.createComponent(DrawingPhaseView);
+    fixture.componentRef.setInput('state', stateForImpostor(42));
+    fixture.componentRef.setInput('myPlayerId', 7);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.querySelector('[data-testid="impostor-guess-box"]')).toBeTruthy();
+  });
+
+  it('PAINTER no ve la caja de adivinación', () => {
+    const fixture = TestBed.createComponent(DrawingPhaseView);
+    fixture.componentRef.setInput('state', stateForPainter(42));
+    fixture.componentRef.setInput('myPlayerId', 7);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.querySelector('[data-testid="impostor-guess-box"]')).toBeNull();
+  });
+
+  it('emite guessSubmitted con el texto cuando IMPOSTOR envía la caja', () => {
+    const fixture = TestBed.createComponent(DrawingPhaseView);
+    fixture.componentRef.setInput('state', stateForImpostor(42));
+    fixture.componentRef.setInput('myPlayerId', 7);
+    fixture.detectChanges();
+
+    let received: string | null = null;
+    fixture.componentInstance.guessSubmitted.subscribe((g) => (received = g));
+
+    const input = fixture.nativeElement.querySelector('[data-testid="impostor-guess-input"]') as HTMLInputElement;
+    input.value = 'guitarra';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('[data-testid="impostor-guess-submit"]') as HTMLButtonElement;
+    button.click();
+
+    expect(received).toBe('guitarra');
+  });
+
+  it('muestra el temporizador con state.timeRemainingSec', () => {
+    const fixture = TestBed.createComponent(DrawingPhaseView);
+    fixture.componentRef.setInput('state', stateForPainter(42));
+    fixture.componentRef.setInput('myPlayerId', 42);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.querySelector('[data-testid="timer"]')?.textContent).toContain('30');
+  });
+
+  it('renderiza placeholder si nadie está dibujando todavía', () => {
+    const fixture = TestBed.createComponent(DrawingPhaseView);
+    fixture.componentRef.setInput('state', stateForPainter(null));
+    fixture.componentRef.setInput('myPlayerId', 42);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.querySelector('[data-testid="waiting-for-turn"]')).toBeTruthy();
+  });
+
+  it('mantiene el atributo data-testid="drawing-phase" en el root para el container', () => {
+    const fixture = TestBed.createComponent(DrawingPhaseView);
+    fixture.componentRef.setInput('state', stateForPainter(42));
+    fixture.componentRef.setInput('myPlayerId', 42);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.querySelector('[data-testid="drawing-phase"]')).toBeTruthy();
+  });
+
+  describe('reenvío de strokes via drawCommand', () => {
+    it('cuando canDraw, un stroke local del CanvasService emite drawCommand STROKE sin playerId/timestamp', async () => {
+      const { CanvasService } = await import('../../services/canvas');
+      const fixture = TestBed.createComponent(DrawingPhaseView);
+      fixture.componentRef.setInput('state', stateForPainter(42));
+      fixture.componentRef.setInput('myPlayerId', 42);
+      fixture.detectChanges();
+
+      const emitted: any[] = [];
+      fixture.componentInstance.drawCommand.subscribe((c) => emitted.push(c));
+
+      const canvasSvc = TestBed.inject(CanvasService);
+      canvasSvc.emitStroke({
+        type: 'STROKE',
+        points: [{ x: 1, y: 2 }, { x: 3, y: 4 }],
+        color: '#ff0000',
+        thickness: 3,
+        timestamp: 12345,
+      });
+
+      expect(emitted).toEqual([
+        {
+          type: 'STROKE',
+          points: [{ x: 1, y: 2 }, { x: 3, y: 4 }],
+          color: '#ff0000',
+          thickness: 3,
+        },
+      ]);
+    });
+
+    it('cuando canDraw, un clearCanvas() local emite drawCommand CLEAR sin payload extra', async () => {
+      const { CanvasService } = await import('../../services/canvas');
+      const fixture = TestBed.createComponent(DrawingPhaseView);
+      fixture.componentRef.setInput('state', stateForPainter(42));
+      fixture.componentRef.setInput('myPlayerId', 42);
+      fixture.detectChanges();
+
+      const emitted: any[] = [];
+      fixture.componentInstance.drawCommand.subscribe((c) => emitted.push(c));
+
+      const canvasSvc = TestBed.inject(CanvasService);
+      canvasSvc.clearCanvas();
+
+      expect(emitted).toEqual([{ type: 'CLEAR' }]);
+    });
+
+    it('cuando NO es mi turno, los strokes locales NO se reenvían', async () => {
+      const { CanvasService } = await import('../../services/canvas');
+      const fixture = TestBed.createComponent(DrawingPhaseView);
+      fixture.componentRef.setInput('state', stateForPainter(42));
+      fixture.componentRef.setInput('myPlayerId', 7); // dibujante=42, yo=7 → modo espectador
+      fixture.detectChanges();
+
+      const emitted: any[] = [];
+      fixture.componentInstance.drawCommand.subscribe((c) => emitted.push(c));
+
+      const canvasSvc = TestBed.inject(CanvasService);
+      canvasSvc.emitStroke({ type: 'STROKE', points: [{ x: 0, y: 0 }, { x: 1, y: 1 }], color: '#000', thickness: 1 });
+
+      expect(emitted).toEqual([]);
+    });
+
+    it('IMPOSTOR no emite drawCommand aunque haya strokes locales (defensivo)', async () => {
+      const { CanvasService } = await import('../../services/canvas');
+      const fixture = TestBed.createComponent(DrawingPhaseView);
+      fixture.componentRef.setInput('state', stateForImpostor(7)); // turno del impostor (que no debería ocurrir, pero defensa)
+      fixture.componentRef.setInput('myPlayerId', 7);
+      fixture.detectChanges();
+
+      const emitted: any[] = [];
+      fixture.componentInstance.drawCommand.subscribe((c) => emitted.push(c));
+
+      const canvasSvc = TestBed.inject(CanvasService);
+      canvasSvc.emitStroke({ type: 'STROKE', points: [{ x: 0, y: 0 }, { x: 1, y: 1 }], color: '#000', thickness: 1 });
+
+      expect(emitted).toEqual([]);
+    });
+
+    it('al destruir el componente, deja de reenviar strokes', async () => {
+      const { CanvasService } = await import('../../services/canvas');
+      const fixture = TestBed.createComponent(DrawingPhaseView);
+      fixture.componentRef.setInput('state', stateForPainter(42));
+      fixture.componentRef.setInput('myPlayerId', 42);
+      fixture.detectChanges();
+
+      const emitted: any[] = [];
+      fixture.componentInstance.drawCommand.subscribe((c) => emitted.push(c));
+      fixture.destroy();
+
+      const canvasSvc = TestBed.inject(CanvasService);
+      canvasSvc.emitStroke({ type: 'STROKE', points: [{ x: 0, y: 0 }, { x: 1, y: 1 }], color: '#000', thickness: 1 });
+
+      expect(emitted).toEqual([]);
+    });
+  });
+});

--- a/frontend/src/app/features/game/components/drawing-phase-view/drawing-phase-view.ts
+++ b/frontend/src/app/features/game/components/drawing-phase-view/drawing-phase-view.ts
@@ -1,0 +1,107 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { Subject, takeUntil } from 'rxjs';
+
+import { GameState } from '../../models/game-state';
+import { DrawCommand } from '../../models/game-event';
+import { CanvasComponent } from '../canvas/canvas';
+import { CanvasService } from '../../services/canvas';
+import { SpectatorCanvasService } from '../../services/spectator-canvas';
+
+/**
+ * 2I.2 — Vista de la fase de dibujo.
+ *
+ * - Si el jugador local es el dibujante actual y es PAINTER → canvas activo (delegado a CanvasComponent).
+ * - En otro caso → modo espectador con miniatura del dibujante actual via SpectatorCanvasService.
+ *
+ * Se subscribe a `CanvasService.getStrokeEmitter()` y reenvía los strokes/clears
+ * locales como `drawCommand` SOLO cuando `canDraw()` es true. El container hace
+ * `stomp.send('/app/room.{code}.draw', cmd)`.
+ *
+ * El IMPOSTOR ve además una caja inline de adivinación. Es un fallback hasta
+ * que P6 entregue 2I.8 (UI flotante del impostor).
+ */
+@Component({
+  selector: 'app-drawing-phase-view',
+  standalone: true,
+  imports: [CanvasComponent],
+  templateUrl: './drawing-phase-view.html',
+  styleUrl: './drawing-phase-view.css',
+})
+export class DrawingPhaseView implements OnInit, OnDestroy {
+  @Input({ required: true }) state!: GameState;
+  @Input() myPlayerId: number | null = null;
+
+  /** Comando de dibujo (STROKE o CLEAR) listo para reenviar al servidor. */
+  @Output() drawCommand = new EventEmitter<DrawCommand>();
+  /** Texto de adivinación enviado por el impostor (fallback hasta 2I.8 de P6). */
+  @Output() guessSubmitted = new EventEmitter<string>();
+
+  protected readonly spectator = inject(SpectatorCanvasService);
+  private readonly canvasService = inject(CanvasService);
+  protected readonly guessText = signal('');
+
+  private readonly destroy$ = new Subject<void>();
+
+  protected readonly isMyTurn = computed(() => {
+    return this.myPlayerId !== null && this.state.currentDrawerId === this.myPlayerId;
+  });
+
+  protected readonly isImpostor = computed(() => this.state.myRole === 'IMPOSTOR');
+
+  protected readonly canDraw = computed(() => this.isMyTurn() && this.state.myRole === 'PAINTER');
+
+  protected readonly drawerSnapshot = computed(() => {
+    const id = this.state.currentDrawerId;
+    if (id === null) return null;
+    return this.spectator.snapshots()[id] ?? null;
+  });
+
+  ngOnInit(): void {
+    // Reenvía cada stroke/clear local al servidor, condicional a canDraw().
+    // La lectura de canDraw() en el momento del evento (no en init) es
+    // intencional: el estado de turno cambia durante la vida del componente.
+    this.canvasService
+      .getStrokeEmitter()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((stroke) => {
+        if (!this.canDraw()) return;
+        if (stroke.type === 'STROKE') {
+          this.drawCommand.emit({
+            type: 'STROKE',
+            points: stroke.points,
+            color: stroke.color,
+            thickness: stroke.thickness,
+          });
+        } else {
+          this.drawCommand.emit({ type: 'CLEAR' });
+        }
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  protected onGuessInput(event: Event): void {
+    this.guessText.set((event.target as HTMLInputElement).value);
+  }
+
+  protected submitGuess(): void {
+    const text = this.guessText().trim();
+    if (text.length > 0) {
+      this.guessSubmitted.emit(text);
+      this.guessText.set('');
+    }
+  }
+}

--- a/frontend/src/app/features/game/components/gallery-view/gallery-view.css
+++ b/frontend/src/app/features/game/components/gallery-view/gallery-view.css
@@ -1,0 +1,2 @@
+.phase-placeholder { padding: 1rem; border: 2px dashed #999; border-radius: 8px; background: #fafafa; }
+.phase-placeholder pre { font-size: 0.75rem; background: #eee; padding: 0.5rem; border-radius: 4px; overflow-x: auto; }

--- a/frontend/src/app/features/game/components/gallery-view/gallery-view.html
+++ b/frontend/src/app/features/game/components/gallery-view/gallery-view.html
@@ -1,0 +1,5 @@
+<div class="phase-placeholder" data-testid="gallery-phase">
+  <h2>Fase: GALLERY</h2>
+  <p><em>PLACEHOLDER — P3/P4 implementará la cuadrícula de canvas (sec 2I.3).</em></p>
+  <pre>{{ state | json }}</pre>
+</div>

--- a/frontend/src/app/features/game/components/gallery-view/gallery-view.spec.ts
+++ b/frontend/src/app/features/game/components/gallery-view/gallery-view.spec.ts
@@ -1,0 +1,18 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { GalleryView } from './gallery-view';
+import { INITIAL_STATE } from '../../models/game-state';
+
+describe('GalleryView (placeholder)', () => {
+  beforeEach(() => TestBed.configureTestingModule({ imports: [GalleryView] }));
+
+  it('crea el componente y renderiza el header de fase', () => {
+    const fixture = TestBed.createComponent(GalleryView);
+    fixture.componentRef.setInput('state', { ...INITIAL_STATE, phase: 'GALLERY' });
+    fixture.detectChanges();
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.querySelector('[data-testid="gallery-phase"]')).toBeTruthy();
+    expect(root.textContent).toContain('Fase: GALLERY');
+  });
+});

--- a/frontend/src/app/features/game/components/gallery-view/gallery-view.ts
+++ b/frontend/src/app/features/game/components/gallery-view/gallery-view.ts
@@ -1,0 +1,18 @@
+// PLACEHOLDER — P3/P4 reemplazará con TDD (ver docs/track-i-plan.md, sec 2I.3).
+// Vista real: cuadrícula de N canvas snapshots de los jugadores de la ronda.
+
+import { Component, Input } from '@angular/core';
+import { JsonPipe } from '@angular/common';
+
+import { GameState } from '../../models/game-state';
+
+@Component({
+  selector: 'app-gallery-view',
+  standalone: true,
+  imports: [JsonPipe],
+  templateUrl: './gallery-view.html',
+  styleUrl: './gallery-view.css',
+})
+export class GalleryView {
+  @Input({ required: true }) state!: GameState;
+}

--- a/frontend/src/app/features/game/components/game-over-view/game-over-view.css
+++ b/frontend/src/app/features/game/components/game-over-view/game-over-view.css
@@ -1,0 +1,83 @@
+.game-over-view {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
+  padding: 1.5rem;
+  text-align: center;
+}
+
+.winner-banner {
+  padding: 2rem 1rem;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+}
+
+.winner-banner.painters {
+  background: linear-gradient(135deg, #ecfdf5 0%, #d1fae5 100%);
+  border: 2px solid #10b981;
+}
+
+.winner-banner.impostor {
+  background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
+  border: 2px solid #f59e0b;
+}
+
+.winner-banner h2 {
+  margin: 0 0 0.5rem 0;
+  font-size: 2rem;
+}
+
+.winner-banner .reason {
+  margin: 0;
+  color: #555;
+  font-size: 1rem;
+}
+
+.reveal {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0 auto 1.5rem auto;
+  max-width: 480px;
+  text-align: left;
+}
+
+.reveal-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  background: #f9fafb;
+  border-radius: 4px;
+  border: 1px solid #e5e7eb;
+  margin: 0;
+}
+
+.reveal-row dt {
+  font-weight: 600;
+  color: #555;
+}
+
+.reveal-row dd {
+  margin: 0;
+  color: #111;
+}
+
+.play-again {
+  background: #2563eb;
+  color: white;
+  border: none;
+  padding: 0.75rem 2rem;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.play-again:hover {
+  background: #1d4ed8;
+}
+
+.no-game-over {
+  padding: 2rem;
+  color: #999;
+}

--- a/frontend/src/app/features/game/components/game-over-view/game-over-view.html
+++ b/frontend/src/app/features/game/components/game-over-view/game-over-view.html
@@ -1,0 +1,41 @@
+<div class="game-over-view" data-testid="game-over-phase">
+  @if (state.gameOver; as g) {
+    <div class="winner-banner" [class.painters]="g.winner === 'PAINTERS'" [class.impostor]="g.winner === 'IMPOSTOR'">
+      <h2 data-testid="winner">
+        @if (g.winner === 'PAINTERS') {
+          🎨 Ganan los Pintores
+        } @else {
+          🕵️ Gana el Impostor
+        }
+      </h2>
+      <p class="reason" data-testid="reason">{{ reasonText(g.reason) }}</p>
+    </div>
+
+    <dl class="reveal">
+      <div class="reveal-row">
+        <dt>Palabra secreta</dt>
+        <dd data-testid="secret-word"><strong>{{ g.secretWord }}</strong></dd>
+      </div>
+      <div class="reveal-row">
+        <dt>Pista del impostor</dt>
+        <dd data-testid="hint">{{ state.hint ?? '—' }}</dd>
+      </div>
+      <div class="reveal-row">
+        <dt>Impostor</dt>
+        <dd data-testid="impostor-id">Jugador {{ g.impostorId }}</dd>
+      </div>
+      <div class="reveal-row">
+        <dt>Rondas jugadas</dt>
+        <dd data-testid="rounds">{{ state.round }}</dd>
+      </div>
+    </dl>
+
+    <button class="play-again" data-testid="play-again" (click)="playAgain.emit()">
+      Jugar otra vez
+    </button>
+  } @else {
+    <div data-testid="no-game-over" class="no-game-over">
+      <p>La partida terminó sin información de cierre.</p>
+    </div>
+  }
+</div>

--- a/frontend/src/app/features/game/components/game-over-view/game-over-view.spec.ts
+++ b/frontend/src/app/features/game/components/game-over-view/game-over-view.spec.ts
@@ -1,0 +1,109 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { GameOverView } from './game-over-view';
+import { GameState, INITIAL_STATE } from '../../models/game-state';
+import { EndReason, Winner } from '../../models/game-event';
+
+function gameOverState(
+  winner: Winner,
+  reason: EndReason,
+  impostorId = 7,
+  secretWord = 'guitarra',
+  round = 3,
+): GameState {
+  return {
+    ...INITIAL_STATE,
+    phase: 'OVER',
+    round,
+    hint: 'piano',
+    gameOver: { winner, reason, impostorId, secretWord },
+  };
+}
+
+describe('GameOverView', () => {
+  beforeEach(() => TestBed.configureTestingModule({ imports: [GameOverView] }));
+
+  it('mantiene el atributo data-testid="game-over-phase" en el root', () => {
+    const fixture = TestBed.createComponent(GameOverView);
+    fixture.componentRef.setInput('state', gameOverState('PAINTERS', 'VOTED_OUT'));
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-testid="game-over-phase"]')).toBeTruthy();
+  });
+
+  it('victoria PAINTERS muestra ganador correcto', () => {
+    const fixture = TestBed.createComponent(GameOverView);
+    fixture.componentRef.setInput('state', gameOverState('PAINTERS', 'VOTED_OUT'));
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-testid="winner"]')?.textContent).toContain('Pintores');
+  });
+
+  it('victoria IMPOSTOR muestra ganador correcto', () => {
+    const fixture = TestBed.createComponent(GameOverView);
+    fixture.componentRef.setInput('state', gameOverState('IMPOSTOR', 'WORD_GUESSED'));
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-testid="winner"]')?.textContent).toContain('Impostor');
+  });
+
+  it('revela la palabra secreta', () => {
+    const fixture = TestBed.createComponent(GameOverView);
+    fixture.componentRef.setInput('state', gameOverState('IMPOSTOR', 'WORD_GUESSED', 7, 'guitarra'));
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-testid="secret-word"]')?.textContent).toContain('guitarra');
+  });
+
+  it('revela la pista (de state.hint)', () => {
+    const fixture = TestBed.createComponent(GameOverView);
+    fixture.componentRef.setInput('state', gameOverState('PAINTERS', 'VOTED_OUT'));
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-testid="hint"]')?.textContent).toContain('piano');
+  });
+
+  it('revela el id del impostor', () => {
+    const fixture = TestBed.createComponent(GameOverView);
+    fixture.componentRef.setInput('state', gameOverState('PAINTERS', 'VOTED_OUT', 13));
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-testid="impostor-id"]')?.textContent).toContain('13');
+  });
+
+  it('muestra el número de rondas jugadas', () => {
+    const fixture = TestBed.createComponent(GameOverView);
+    fixture.componentRef.setInput('state', gameOverState('PAINTERS', 'VOTED_OUT', 7, 'g', 5));
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-testid="rounds"]')?.textContent).toContain('5');
+  });
+
+  it.each<[EndReason, string]>([
+    ['VOTED_OUT', 'expulsado'],
+    ['WORD_GUESSED', 'adivinó'],
+    ['OUT_OF_LIVES', 'vidas'],
+    ['TIE_NOT_BROKEN', 'empate'],
+    ['LAST_STANDING', 'último'],
+  ])('traduce EndReason %s a texto humano que contiene "%s"', (reason, expected) => {
+    const fixture = TestBed.createComponent(GameOverView);
+    fixture.componentRef.setInput('state', gameOverState('PAINTERS', reason));
+    fixture.detectChanges();
+    const text = fixture.nativeElement.querySelector('[data-testid="reason"]')?.textContent?.toLowerCase() ?? '';
+    expect(text).toContain(expected);
+  });
+
+  it('botón "jugar otra vez" emite playAgain', () => {
+    const fixture = TestBed.createComponent(GameOverView);
+    fixture.componentRef.setInput('state', gameOverState('PAINTERS', 'VOTED_OUT'));
+    fixture.detectChanges();
+
+    let emitted = false;
+    fixture.componentInstance.playAgain.subscribe(() => (emitted = true));
+
+    const btn = fixture.nativeElement.querySelector('[data-testid="play-again"]') as HTMLButtonElement;
+    btn.click();
+    expect(emitted).toBe(true);
+  });
+
+  it('si state.gameOver es null, muestra mensaje defensivo', () => {
+    const fixture = TestBed.createComponent(GameOverView);
+    fixture.componentRef.setInput('state', { ...INITIAL_STATE, phase: 'OVER' as const });
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-testid="no-game-over"]')).toBeTruthy();
+  });
+});

--- a/frontend/src/app/features/game/components/game-over-view/game-over-view.ts
+++ b/frontend/src/app/features/game/components/game-over-view/game-over-view.ts
@@ -1,0 +1,34 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+import { GameState } from '../../models/game-state';
+import { EndReason } from '../../models/game-event';
+
+const REASON_TEXT: Record<EndReason, string> = {
+  VOTED_OUT: 'El impostor fue expulsado por votación.',
+  WORD_GUESSED: 'El impostor adivinó la palabra secreta.',
+  OUT_OF_LIVES: 'El impostor agotó sus vidas adivinando.',
+  TIE_NOT_BROKEN: 'Hubo un empate y el impostor no movió su voto a tiempo.',
+  LAST_STANDING: 'Solo quedaba un pintor — el impostor sobrevivió hasta el último.',
+};
+
+/**
+ * 2I.7 — Vista de fin de partida.
+ *
+ * Anuncia ganador, revela palabra secreta, pista, identidad del impostor y
+ * número de rondas. Botón "jugar otra vez" emite playAgain.
+ */
+@Component({
+  selector: 'app-game-over-view',
+  standalone: true,
+  imports: [],
+  templateUrl: './game-over-view.html',
+  styleUrl: './game-over-view.css',
+})
+export class GameOverView {
+  @Input({ required: true }) state!: GameState;
+  @Output() playAgain = new EventEmitter<void>();
+
+  protected reasonText(reason: EndReason): string {
+    return REASON_TEXT[reason];
+  }
+}

--- a/frontend/src/app/features/game/components/tie-break-view/tie-break-view.css
+++ b/frontend/src/app/features/game/components/tie-break-view/tie-break-view.css
@@ -1,0 +1,2 @@
+.phase-placeholder { padding: 1rem; border: 2px dashed #999; border-radius: 8px; background: #fafafa; }
+.phase-placeholder pre { font-size: 0.75rem; background: #eee; padding: 0.5rem; border-radius: 4px; overflow-x: auto; }

--- a/frontend/src/app/features/game/components/tie-break-view/tie-break-view.html
+++ b/frontend/src/app/features/game/components/tie-break-view/tie-break-view.html
@@ -1,0 +1,5 @@
+<div class="phase-placeholder" data-testid="tie-break-phase">
+  <h2>Fase: TIE_BREAK</h2>
+  <p><em>PLACEHOLDER — P3/P4 implementará el desempate (sec 2I.5).</em></p>
+  <pre>{{ state | json }}</pre>
+</div>

--- a/frontend/src/app/features/game/components/tie-break-view/tie-break-view.spec.ts
+++ b/frontend/src/app/features/game/components/tie-break-view/tie-break-view.spec.ts
@@ -1,0 +1,18 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { TieBreakView } from './tie-break-view';
+import { INITIAL_STATE } from '../../models/game-state';
+
+describe('TieBreakView (placeholder)', () => {
+  beforeEach(() => TestBed.configureTestingModule({ imports: [TieBreakView] }));
+
+  it('crea el componente y renderiza el header de fase', () => {
+    const fixture = TestBed.createComponent(TieBreakView);
+    fixture.componentRef.setInput('state', { ...INITIAL_STATE, phase: 'TIE_BREAK' });
+    fixture.detectChanges();
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.querySelector('[data-testid="tie-break-phase"]')).toBeTruthy();
+    expect(root.textContent).toContain('Fase: TIE_BREAK');
+  });
+});

--- a/frontend/src/app/features/game/components/tie-break-view/tie-break-view.ts
+++ b/frontend/src/app/features/game/components/tie-break-view/tie-break-view.ts
@@ -1,0 +1,19 @@
+// PLACEHOLDER — P3/P4 reemplazará con TDD (ver docs/track-i-plan.md, sec 2I.5).
+// Vista real: jugadores empatados destacados, IMPOSTOR puede mover su voto.
+
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { JsonPipe } from '@angular/common';
+
+import { GameState } from '../../models/game-state';
+
+@Component({
+  selector: 'app-tie-break-view',
+  standalone: true,
+  imports: [JsonPipe],
+  templateUrl: './tie-break-view.html',
+  styleUrl: './tie-break-view.css',
+})
+export class TieBreakView {
+  @Input({ required: true }) state!: GameState;
+  @Output() voteMoved = new EventEmitter<number>();
+}

--- a/frontend/src/app/features/game/components/vote-result-view/vote-result-view.css
+++ b/frontend/src/app/features/game/components/vote-result-view/vote-result-view.css
@@ -1,0 +1,2 @@
+.phase-placeholder { padding: 1rem; border: 2px dashed #999; border-radius: 8px; background: #fafafa; }
+.phase-placeholder pre { font-size: 0.75rem; background: #eee; padding: 0.5rem; border-radius: 4px; overflow-x: auto; }

--- a/frontend/src/app/features/game/components/vote-result-view/vote-result-view.html
+++ b/frontend/src/app/features/game/components/vote-result-view/vote-result-view.html
@@ -1,0 +1,5 @@
+<div class="phase-placeholder" data-testid="vote-result-phase">
+  <h2>Fase: RESULT</h2>
+  <p><em>PLACEHOLDER — P3/P4 implementará el resultado de votación (sec 2I.6).</em></p>
+  <pre>{{ state | json }}</pre>
+</div>

--- a/frontend/src/app/features/game/components/vote-result-view/vote-result-view.spec.ts
+++ b/frontend/src/app/features/game/components/vote-result-view/vote-result-view.spec.ts
@@ -1,0 +1,18 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { VoteResultView } from './vote-result-view';
+import { INITIAL_STATE } from '../../models/game-state';
+
+describe('VoteResultView (placeholder)', () => {
+  beforeEach(() => TestBed.configureTestingModule({ imports: [VoteResultView] }));
+
+  it('crea el componente y renderiza el header de fase', () => {
+    const fixture = TestBed.createComponent(VoteResultView);
+    fixture.componentRef.setInput('state', { ...INITIAL_STATE, phase: 'RESULT' });
+    fixture.detectChanges();
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.querySelector('[data-testid="vote-result-phase"]')).toBeTruthy();
+    expect(root.textContent).toContain('Fase: RESULT');
+  });
+});

--- a/frontend/src/app/features/game/components/vote-result-view/vote-result-view.ts
+++ b/frontend/src/app/features/game/components/vote-result-view/vote-result-view.ts
@@ -1,0 +1,18 @@
+// PLACEHOLDER — P3/P4 reemplazará con TDD (ver docs/track-i-plan.md, sec 2I.6).
+// Vista real: revela quién fue eliminado y si era el impostor.
+
+import { Component, Input } from '@angular/core';
+import { JsonPipe } from '@angular/common';
+
+import { GameState } from '../../models/game-state';
+
+@Component({
+  selector: 'app-vote-result-view',
+  standalone: true,
+  imports: [JsonPipe],
+  templateUrl: './vote-result-view.html',
+  styleUrl: './vote-result-view.css',
+})
+export class VoteResultView {
+  @Input({ required: true }) state!: GameState;
+}

--- a/frontend/src/app/features/game/components/voting-view/voting-view.css
+++ b/frontend/src/app/features/game/components/voting-view/voting-view.css
@@ -1,0 +1,127 @@
+.voting-view {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
+  padding: 1.25rem;
+}
+
+.phase-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.phase-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #333;
+}
+
+.timer {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  background: #2563eb;
+  color: white;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.875rem;
+}
+
+.instructions {
+  color: #555;
+  margin-bottom: 1rem;
+}
+
+.vote-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.vote-card {
+  background: #fff;
+  border: 2px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 0.75rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  text-align: center;
+  font-family: inherit;
+}
+
+.vote-card:hover:not(:disabled) {
+  border-color: #2563eb;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(37, 99, 235, 0.15);
+}
+
+.vote-card.voted {
+  border-color: #10b981;
+  background: #ecfdf5;
+}
+
+.vote-card.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.vote-card:disabled {
+  cursor: default;
+}
+
+.player-label {
+  font-weight: 600;
+  color: #333;
+}
+
+.self-marker {
+  display: inline-block;
+  margin-left: 0.4rem;
+  padding: 0.1rem 0.4rem;
+  background: #dbeafe;
+  color: #1d4ed8;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.vote-thumb {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: contain;
+  background: #fafafa;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
+.no-drawing {
+  aspect-ratio: 4 / 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f9fafb;
+  border: 1px dashed #d1d5db;
+  border-radius: 4px;
+  color: #999;
+  font-size: 0.875rem;
+}
+
+.vote-marker {
+  background: #10b981;
+  color: white;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.confirmation {
+  margin-top: 1rem;
+  text-align: center;
+  color: #10b981;
+  font-weight: 600;
+}

--- a/frontend/src/app/features/game/components/voting-view/voting-view.html
+++ b/frontend/src/app/features/game/components/voting-view/voting-view.html
@@ -1,0 +1,40 @@
+<div class="voting-view" data-testid="voting-phase">
+  <header class="phase-header">
+    <h2>Fase de votación — Ronda {{ state.round }}</h2>
+    <div class="timer" data-testid="timer">⏱ {{ state.timeRemainingSec }}s</div>
+  </header>
+
+  <p class="instructions">¿Quién crees que es el impostor? Vota tocando una tarjeta.</p>
+
+  <div class="vote-grid">
+    @for (id of votablePlayers(); track id) {
+      <button
+        class="vote-card"
+        [class.voted]="myVote() === id"
+        [class.disabled]="myVote() !== null && myVote() !== id"
+        [disabled]="myVote() !== null"
+        [attr.data-testid]="'vote-card-' + id"
+        (click)="onVote(id)"
+      >
+        <div class="player-label">
+          Jugador {{ id }}
+          @if (id === myPlayerId) {
+            <span class="self-marker" data-testid="self-marker">(Tú)</span>
+          }
+        </div>
+        @if (snapshotFor(id); as src) {
+          <img [src]="src" alt="Dibujo del jugador {{ id }}" class="vote-thumb" />
+        } @else {
+          <div class="no-drawing">(sin dibujo)</div>
+        }
+        @if (myVote() === id) {
+          <div class="vote-marker">✓ Tu voto</div>
+        }
+      </button>
+    }
+  </div>
+
+  @if (myVote() !== null) {
+    <p class="confirmation">Voto registrado. Esperando al resto…</p>
+  }
+</div>

--- a/frontend/src/app/features/game/components/voting-view/voting-view.spec.ts
+++ b/frontend/src/app/features/game/components/voting-view/voting-view.spec.ts
@@ -1,0 +1,165 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { VotingView } from './voting-view';
+import { GameState, INITIAL_STATE } from '../../models/game-state';
+import { SpectatorCanvasService } from '../../services/spectator-canvas';
+
+function baseState(): GameState {
+  return {
+    ...INITIAL_STATE,
+    phase: 'VOTING',
+    round: 1,
+    drawingOrder: [42, 7, 13],
+    timeRemainingSec: 30,
+    myRole: 'PAINTER',
+    secretWord: 'guitarra',
+  };
+}
+
+describe('VotingView', () => {
+  let snapshotsStore: Record<number, string>;
+
+  beforeEach(() => {
+    snapshotsStore = { 42: 'data:img/42', 7: 'data:img/7', 13: 'data:img/13' };
+    TestBed.configureTestingModule({
+      imports: [VotingView],
+      providers: [
+        {
+          provide: SpectatorCanvasService,
+          useValue: {
+            snapshots: () => snapshotsStore,
+            replayStroke: vi.fn(),
+            clearPlayer: vi.fn(),
+            replayBroadcast: vi.fn(),
+          },
+        },
+      ],
+    });
+  });
+
+  it('renderiza una tarjeta por jugador en drawingOrder', () => {
+    const fixture = TestBed.createComponent(VotingView);
+    fixture.componentRef.setInput('state', baseState());
+    fixture.componentRef.setInput('myPlayerId', 42);
+    fixture.detectChanges();
+
+    const cards = (fixture.nativeElement as HTMLElement).querySelectorAll('[data-testid^="vote-card-"]');
+    expect(cards).toHaveLength(3);
+  });
+
+  it('cada tarjeta muestra la miniatura del canvas del jugador', () => {
+    const fixture = TestBed.createComponent(VotingView);
+    fixture.componentRef.setInput('state', baseState());
+    fixture.componentRef.setInput('myPlayerId', 42);
+    fixture.detectChanges();
+
+    const img42 = (fixture.nativeElement as HTMLElement).querySelector(
+      '[data-testid="vote-card-42"] img',
+    ) as HTMLImageElement;
+    expect(img42.getAttribute('src')).toBe('data:img/42');
+  });
+
+  it('click en tarjeta emite voteCast con el playerId', () => {
+    const fixture = TestBed.createComponent(VotingView);
+    fixture.componentRef.setInput('state', baseState());
+    fixture.componentRef.setInput('myPlayerId', 42);
+    fixture.detectChanges();
+
+    let voted: number | null = null;
+    fixture.componentInstance.voteCast.subscribe((id) => (voted = id));
+
+    const card7 = fixture.nativeElement.querySelector('[data-testid="vote-card-7"]') as HTMLElement;
+    card7.click();
+    fixture.detectChanges();
+
+    expect(voted).toBe(7);
+  });
+
+  it('después de votar, no permite votar otra vez', () => {
+    const fixture = TestBed.createComponent(VotingView);
+    fixture.componentRef.setInput('state', baseState());
+    fixture.componentRef.setInput('myPlayerId', 42);
+    fixture.detectChanges();
+
+    const emissions: number[] = [];
+    fixture.componentInstance.voteCast.subscribe((id) => emissions.push(id));
+
+    const card7 = fixture.nativeElement.querySelector('[data-testid="vote-card-7"]') as HTMLElement;
+    card7.click();
+    fixture.detectChanges();
+    card7.click();
+    fixture.detectChanges();
+    const card13 = fixture.nativeElement.querySelector('[data-testid="vote-card-13"]') as HTMLElement;
+    card13.click();
+    fixture.detectChanges();
+
+    expect(emissions).toEqual([7]);
+  });
+
+  it('marca visualmente la tarjeta votada con clase "voted"', () => {
+    const fixture = TestBed.createComponent(VotingView);
+    fixture.componentRef.setInput('state', baseState());
+    fixture.componentRef.setInput('myPlayerId', 42);
+    fixture.detectChanges();
+
+    const card7 = fixture.nativeElement.querySelector('[data-testid="vote-card-7"]') as HTMLElement;
+    card7.click();
+    fixture.detectChanges();
+
+    expect(card7.classList.contains('voted')).toBe(true);
+  });
+
+  it('excluye al jugador eliminado de las tarjetas', () => {
+    const fixture = TestBed.createComponent(VotingView);
+    fixture.componentRef.setInput('state', { ...baseState(), eliminated: 7 });
+    fixture.componentRef.setInput('myPlayerId', 42);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="vote-card-7"]')).toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="vote-card-42"]')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('[data-testid="vote-card-13"]')).toBeTruthy();
+  });
+
+  it('muestra el temporizador con state.timeRemainingSec', () => {
+    const fixture = TestBed.createComponent(VotingView);
+    fixture.componentRef.setInput('state', baseState());
+    fixture.componentRef.setInput('myPlayerId', 42);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="timer"]')?.textContent).toContain('30');
+  });
+
+  it('marca la tarjeta del jugador local con etiqueta "(Tú)"', () => {
+    const fixture = TestBed.createComponent(VotingView);
+    fixture.componentRef.setInput('state', baseState());
+    fixture.componentRef.setInput('myPlayerId', 42);
+    fixture.detectChanges();
+
+    const card42 = fixture.nativeElement.querySelector('[data-testid="vote-card-42"]') as HTMLElement;
+    const card7 = fixture.nativeElement.querySelector('[data-testid="vote-card-7"]') as HTMLElement;
+
+    expect(card42.querySelector('[data-testid="self-marker"]')?.textContent).toContain('Tú');
+    expect(card7.querySelector('[data-testid="self-marker"]')).toBeNull();
+  });
+
+  it('mantiene el atributo data-testid="voting-phase" en el root', () => {
+    const fixture = TestBed.createComponent(VotingView);
+    fixture.componentRef.setInput('state', baseState());
+    fixture.componentRef.setInput('myPlayerId', 42);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="voting-phase"]')).toBeTruthy();
+  });
+
+  it('si no hay snapshot disponible, muestra placeholder "(sin dibujo)"', () => {
+    snapshotsStore = {}; // todos los jugadores sin dibujo aún
+    const fixture = TestBed.createComponent(VotingView);
+    fixture.componentRef.setInput('state', baseState());
+    fixture.componentRef.setInput('myPlayerId', 42);
+    fixture.detectChanges();
+
+    const card42 = fixture.nativeElement.querySelector('[data-testid="vote-card-42"]') as HTMLElement;
+    expect(card42.textContent).toContain('sin dibujo');
+  });
+});

--- a/frontend/src/app/features/game/components/voting-view/voting-view.ts
+++ b/frontend/src/app/features/game/components/voting-view/voting-view.ts
@@ -1,0 +1,42 @@
+import { Component, EventEmitter, Input, Output, computed, inject, signal } from '@angular/core';
+
+import { GameState } from '../../models/game-state';
+import { SpectatorCanvasService } from '../../services/spectator-canvas';
+
+/**
+ * 2I.4 — Vista de votación.
+ *
+ * Tarjetas de jugadores vivos con miniatura del dibujo. Click en una tarjeta
+ * emite `voteCast` y bloquea reintentos (un voto por jugador). Excluye a los
+ * jugadores ya eliminados (`state.eliminated`).
+ */
+@Component({
+  selector: 'app-voting-view',
+  standalone: true,
+  imports: [],
+  templateUrl: './voting-view.html',
+  styleUrl: './voting-view.css',
+})
+export class VotingView {
+  @Input({ required: true }) state!: GameState;
+  @Input() myPlayerId: number | null = null;
+
+  @Output() voteCast = new EventEmitter<number>();
+
+  protected readonly spectator = inject(SpectatorCanvasService);
+  protected readonly myVote = signal<number | null>(null);
+
+  protected readonly votablePlayers = computed(() => {
+    return this.state.drawingOrder.filter((id) => id !== this.state.eliminated);
+  });
+
+  protected snapshotFor(playerId: number): string | null {
+    return this.spectator.snapshots()[playerId] ?? null;
+  }
+
+  protected onVote(playerId: number): void {
+    if (this.myVote() !== null) return;
+    this.myVote.set(playerId);
+    this.voteCast.emit(playerId);
+  }
+}

--- a/frontend/src/app/features/game/containers/game/game.css
+++ b/frontend/src/app/features/game/containers/game/game.css
@@ -1,0 +1,23 @@
+:host {
+  display: block;
+  padding: 1.5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.not-auth, .connecting {
+  padding: 2rem;
+  text-align: center;
+  background: #fff8e1;
+  border: 2px dashed #f9a825;
+  border-radius: 8px;
+}
+
+.dev-banner {
+  background: #2563eb;
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+}

--- a/frontend/src/app/features/game/containers/game/game.html
+++ b/frontend/src/app/features/game/containers/game/game.html
@@ -1,0 +1,50 @@
+@if (notAuthenticated) {
+  <div class="not-auth" data-testid="not-auth">
+    <h2>No autenticado</h2>
+    <p>Necesitas iniciar sesión para entrar a una sala de juego.</p>
+    <p><em>(O añade <code>?dev=true</code> a la URL para entrar en modo demo.)</em></p>
+  </div>
+} @else {
+  @if (devMode) {
+    <div class="dev-banner">🛠️ MODO DEV — eventos generados localmente por MockGameEventEmitter</div>
+  }
+
+  @switch (gameState.phase()) {
+    @case ('CONNECTING') {
+      <div class="connecting"><h2>Conectando…</h2></div>
+    }
+    @case ('DRAWING') {
+      <app-drawing-phase-view
+        [state]="gameState.state()"
+        [myPlayerId]="myPlayerId"
+        (drawCommand)="sendDraw($event)"
+        (guessSubmitted)="sendGuess($event)"
+      />
+    }
+    @case ('GALLERY') {
+      <app-gallery-view [state]="gameState.state()" />
+    }
+    @case ('VOTING') {
+      <app-voting-view
+        [state]="gameState.state()"
+        [myPlayerId]="myPlayerId"
+        (voteCast)="sendVote($event)"
+      />
+    }
+    @case ('TIE_BREAK') {
+      <app-tie-break-view [state]="gameState.state()" />
+    }
+    @case ('RESULT') {
+      <app-vote-result-view [state]="gameState.state()" />
+    }
+    @case ('OVER') {
+      <app-game-over-view
+        [state]="gameState.state()"
+        (playAgain)="onPlayAgain()"
+      />
+    }
+  }
+
+  <!-- Slot para 2I.8 (P6): UI flotante del impostor. -->
+  <ng-content select="[impostorOverlay]" />
+}

--- a/frontend/src/app/features/game/containers/game/game.spec.ts
+++ b/frontend/src/app/features/game/containers/game/game.spec.ts
@@ -1,0 +1,137 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { of } from 'rxjs';
+
+import { GameComponent } from './game';
+import { GameStateService } from '../../services/game-state';
+import { MockGameEventEmitter } from '../../services/mock-game-event-emitter';
+import { StompClientService } from '../../../realtime/services/stomp-client';
+
+describe('GameComponent', () => {
+  let mockEmitter: MockGameEventEmitter;
+  let stompMock: { connect: any; subscribe: any; send: any; disconnect: any; status$: any };
+
+  function configure(devMode: boolean, code = 'TEST') {
+    stompMock = {
+      connect: vi.fn(),
+      subscribe: vi.fn().mockReturnValue(of()),
+      send: vi.fn(),
+      disconnect: vi.fn(),
+      status$: of('IDLE'),
+    };
+
+    TestBed.configureTestingModule({
+      imports: [GameComponent],
+      providers: [
+        GameStateService,
+        MockGameEventEmitter,
+        { provide: StompClientService, useValue: stompMock },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: convertToParamMap({ code }),
+              queryParamMap: convertToParamMap(devMode ? { dev: 'true' } : {}),
+            },
+          },
+        },
+      ],
+    });
+    mockEmitter = TestBed.inject(MockGameEventEmitter);
+  }
+
+  it('muestra placeholder de DRAWING cuando llega GAME_START', () => {
+    configure(true);
+    const fixture = TestBed.createComponent(GameComponent);
+    fixture.detectChanges();
+
+    mockEmitter.emit({ type: 'GAME_START', drawingOrder: [42, 7], round: 1 });
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.querySelector('[data-testid="drawing-phase"]')).toBeTruthy();
+  });
+
+  it('muestra placeholder de GALLERY cuando llega GALLERY_PHASE', () => {
+    configure(true);
+    const fixture = TestBed.createComponent(GameComponent);
+    fixture.detectChanges();
+
+    mockEmitter.emit({ type: 'GAME_START', drawingOrder: [42], round: 1 });
+    mockEmitter.emit({ type: 'GALLERY_PHASE' });
+    fixture.detectChanges();
+
+    expect((fixture.nativeElement as HTMLElement).querySelector('[data-testid="gallery-phase"]')).toBeTruthy();
+  });
+
+  it('muestra placeholder de VOTING cuando llega VOTE_PHASE', () => {
+    configure(true);
+    const fixture = TestBed.createComponent(GameComponent);
+    fixture.detectChanges();
+
+    mockEmitter.emit({ type: 'VOTE_PHASE', timeSeconds: 30 });
+    fixture.detectChanges();
+    expect((fixture.nativeElement as HTMLElement).querySelector('[data-testid="voting-phase"]')).toBeTruthy();
+  });
+
+  it('muestra placeholder de TIE_BREAK cuando llega VOTE_TIE', () => {
+    configure(true);
+    const fixture = TestBed.createComponent(GameComponent);
+    fixture.detectChanges();
+
+    mockEmitter.emit({ type: 'VOTE_TIE', tiedPlayers: [{ id: 7, votes: 3 }], timeSeconds: 15 });
+    fixture.detectChanges();
+    expect((fixture.nativeElement as HTMLElement).querySelector('[data-testid="tie-break-phase"]')).toBeTruthy();
+  });
+
+  it('muestra placeholder de RESULT cuando llega VOTE_RESULT', () => {
+    configure(true);
+    const fixture = TestBed.createComponent(GameComponent);
+    fixture.detectChanges();
+
+    mockEmitter.emit({
+      type: 'VOTE_RESULT',
+      eliminated: 7,
+      wasImpostor: false,
+      topVoted: [{ id: 7, votes: 3 }],
+    });
+    fixture.detectChanges();
+    expect((fixture.nativeElement as HTMLElement).querySelector('[data-testid="vote-result-phase"]')).toBeTruthy();
+  });
+
+  it('muestra placeholder de OVER cuando llega GAME_OVER', () => {
+    configure(true);
+    const fixture = TestBed.createComponent(GameComponent);
+    fixture.detectChanges();
+
+    mockEmitter.emit({
+      type: 'GAME_OVER',
+      winner: 'PAINTERS',
+      reason: 'VOTED_OUT',
+      impostorId: 7,
+      secretWord: 'guitarra',
+    });
+    fixture.detectChanges();
+    expect((fixture.nativeElement as HTMLElement).querySelector('[data-testid="game-over-phase"]')).toBeTruthy();
+  });
+
+  it('en modo no-dev sin token, muestra mensaje de no autenticado', () => {
+    configure(false);
+    const fixture = TestBed.createComponent(GameComponent);
+    fixture.detectChanges();
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.textContent).toContain('No autenticado');
+    expect(stompMock.connect).not.toHaveBeenCalled();
+  });
+
+  it('ngOnDestroy invoca disconnect cuando se conectó por stomp', () => {
+    configure(false);
+    // Simulamos token presente vía Storage.prototype.
+    vi.spyOn(Storage.prototype, 'getItem').mockReturnValue('fake-token');
+    const fixture = TestBed.createComponent(GameComponent);
+    fixture.detectChanges();
+    fixture.destroy();
+    expect(stompMock.disconnect).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/features/game/containers/game/game.ts
+++ b/frontend/src/app/features/game/containers/game/game.ts
@@ -1,0 +1,171 @@
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Subject, takeUntil } from 'rxjs';
+
+import { GameStateService } from '../../services/game-state';
+import { MockGameEventEmitter } from '../../services/mock-game-event-emitter';
+import { SpectatorCanvasService } from '../../services/spectator-canvas';
+import { StompClientService } from '../../../realtime/services/stomp-client';
+import { DrawingPhaseView } from '../../components/drawing-phase-view/drawing-phase-view';
+import { GalleryView } from '../../components/gallery-view/gallery-view';
+import { VotingView } from '../../components/voting-view/voting-view';
+import { TieBreakView } from '../../components/tie-break-view/tie-break-view';
+import { VoteResultView } from '../../components/vote-result-view/vote-result-view';
+import { GameOverView } from '../../components/game-over-view/game-over-view';
+import { DrawBroadcast, DrawCommand, GameEvent } from '../../models/game-event';
+import { RoleAssignment } from '../../models/role-assignment';
+import { getStoredToken } from '../../../../core/auth/token';
+
+/**
+ * Container raíz del flujo del juego (Track I, 2I.1).
+ *
+ * Responsabilidades:
+ *  - Conectar al WebSocket con el JWT del usuario (o usar MockGameEventEmitter en modo ?dev=true)
+ *  - Suscribirse a /topic/room.{code}.game, /topic/room.{code}.draw y /user/queue/private
+ *  - Aplicar cada evento al GameStateService / SpectatorCanvasService
+ *  - Renderizar la sub-vista correcta según gameState.phase()
+ *  - Slot <ng-content> para que P6 enchufe el ImpostorOverlay (2I.8)
+ *
+ * No contiene lógica de juego — solo orquestación.
+ */
+@Component({
+  selector: 'app-game',
+  standalone: true,
+  imports: [
+    DrawingPhaseView,
+    GalleryView,
+    VotingView,
+    TieBreakView,
+    VoteResultView,
+    GameOverView,
+  ],
+  templateUrl: './game.html',
+  styleUrl: './game.css',
+})
+export class GameComponent implements OnInit, OnDestroy {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly stomp = inject(StompClientService);
+  private readonly mock = inject(MockGameEventEmitter);
+  readonly gameState = inject(GameStateService);
+  // Inyectado para que el servicio se construya y se subscriba a gameEvents$
+  // (reset automático en GAME_START / NEW_ROUND). Se pasa via DI a las vistas.
+  private readonly spectator = inject(SpectatorCanvasService);
+
+  /** JWT crudo de localStorage. PENDING — Track E lo reemplazará con AuthService.getToken().
+   *  Se lee como field initializer (contexto de inyección válido). */
+  private readonly storedToken = getStoredToken();
+
+  /** Id del jugador local. PENDING — Track E lo extraerá del JWT decodificado.
+   *  En modo dev hardcoded a 42 (coincide con el guion de MockGameEventEmitter). */
+  protected myPlayerId: number | null = null;
+
+  /** True si no se conecta a Stomp (sin token y sin ?dev=true). */
+  notAuthenticated = false;
+
+  /** True si estamos usando el emitter mock (modo dev). */
+  devMode = false;
+
+  private readonly destroy$ = new Subject<void>();
+  private connectedToStomp = false;
+
+  ngOnInit(): void {
+    const code = this.route.snapshot.paramMap.get('code') ?? '';
+    this.devMode = this.route.snapshot.queryParamMap.get('dev') === 'true';
+
+    if (this.devMode) {
+      this.myPlayerId = 42;
+      this.wireMockEmitter();
+      // Aviso visual inicial para el demo.
+      queueMicrotask(() => this.mock.emitPainterAssignment('guitarra'));
+      queueMicrotask(() => this.mock.playFullGameScript());
+      return;
+    }
+
+    if (!this.storedToken) {
+      this.notAuthenticated = true;
+      return;
+    }
+
+    this.connectStomp(code, this.storedToken);
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+    this.mock.cancel();
+    if (this.connectedToStomp) {
+      this.stomp.disconnect();
+    }
+    this.gameState.reset();
+  }
+
+  // ── Wiring ───────────────────────────────────────────────────────────────
+
+  private wireMockEmitter(): void {
+    this.mock
+      .asObservable()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((ev: GameEvent) => this.gameState.applyEvent(ev));
+    this.mock
+      .asRoleObservable()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((role: RoleAssignment) => this.gameState.applyRoleAssignment(role));
+  }
+
+  private connectStomp(code: string, token: string): void {
+    this.stomp.connect({ url: '/ws', jwt: token });
+    this.connectedToStomp = true;
+
+    this.stomp
+      .subscribe<GameEvent>(`/topic/room.${code}.game`)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((ev) => this.gameState.applyEvent(ev));
+
+    this.stomp
+      .subscribe<DrawBroadcast>(`/topic/room.${code}.draw`)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((broadcast) => this.spectator.replayBroadcast(broadcast));
+
+    this.stomp
+      .subscribe<RoleAssignment>('/user/queue/private')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((msg) => {
+        if (msg.type === 'ROLE_ASSIGNMENT') {
+          this.gameState.applyRoleAssignment(msg);
+        }
+        // GuessResult del impostor: lo deja al GameStateService como mejora futura.
+      });
+  }
+
+  /**
+   * Reenvía un comando de dibujo (STROKE o CLEAR) al servidor.
+   * Invocado por DrawingPhaseView cuando el jugador local está dibujando.
+   * El servidor añade el `playerId` desde el Principal autenticado.
+   */
+  protected sendDraw(cmd: DrawCommand): void {
+    const code = this.route.snapshot.paramMap.get('code') ?? '';
+    this.stomp.send(`/app/room.${code}.draw`, cmd);
+  }
+
+  /** Envía el voto al servidor. Invocado por VotingView. */
+  protected sendVote(votedPlayerId: number): void {
+    const code = this.route.snapshot.paramMap.get('code') ?? '';
+    this.stomp.send(`/app/room.${code}.vote`, { votedPlayerId });
+  }
+
+  /** Envía un intento de adivinación. Invocado por DrawingPhaseView (fallback impostor). */
+  protected sendGuess(guess: string): void {
+    const code = this.route.snapshot.paramMap.get('code') ?? '';
+    this.stomp.send(`/app/room.${code}.guess`, { guess });
+  }
+
+  /**
+   * Botón "jugar otra vez" en GameOverView. PENDING — Track F definirá el flujo
+   * definitivo (volver al lobby, crear nueva sala, etc.). Mientras tanto navego
+   * al home `/` para no dejar el botón sin efecto.
+   */
+  protected onPlayAgain(): void {
+    this.router.navigate(['/']);
+  }
+}

--- a/frontend/src/app/features/game/models/game-event.ts
+++ b/frontend/src/app/features/game/models/game-event.ts
@@ -1,0 +1,55 @@
+// Espejo TypeScript del sealed interface GameEvent del backend Track D.
+// Mantener sincronizado con:
+//   backend/src/main/java/com/impaintor/feature/realtime/dto/outbound/GameEvent.java
+
+export interface TopVote {
+  id: number;
+  votes: number;
+}
+
+export type EndReason =
+  | 'VOTED_OUT'
+  | 'WORD_GUESSED'
+  | 'OUT_OF_LIVES'
+  | 'TIE_NOT_BROKEN'
+  | 'LAST_STANDING';
+
+export type Winner = 'PAINTERS' | 'IMPOSTOR';
+
+/** Discriminated union de todos los eventos del juego que el servidor difunde a /topic/room.{code}.game. */
+export type GameEvent =
+  | { type: 'GAME_START'; drawingOrder: number[]; round: number }
+  | { type: 'TURN_START'; playerId: number; timeSeconds: number }
+  | { type: 'TURN_END'; playerId: number }
+  | { type: 'GALLERY_PHASE' }
+  | { type: 'VOTE_PHASE'; timeSeconds: number }
+  | { type: 'VOTE_RESULT'; eliminated: number; wasImpostor: boolean; topVoted: TopVote[] }
+  | { type: 'VOTE_TIE'; tiedPlayers: TopVote[]; timeSeconds: number }
+  | { type: 'GUESS_ATTEMPT'; livesRemaining: number; correct: boolean }
+  | { type: 'NEW_ROUND'; round: number; drawingOrder: number[] }
+  | { type: 'GAME_OVER'; winner: Winner; reason: EndReason; impostorId: number; secretWord: string };
+
+/** Strokes y limpiezas que el servidor reenvía a /topic/room.{code}.draw. */
+export interface StrokeBroadcast {
+  type: 'STROKE';
+  playerId: number;
+  points: { x: number; y: number }[];
+  color: string;
+  thickness: number;
+}
+
+export interface ClearCanvasBroadcast {
+  type: 'CLEAR';
+  playerId: number;
+}
+
+export type DrawBroadcast = StrokeBroadcast | ClearCanvasBroadcast;
+
+/**
+ * Comandos de dibujo que el cliente envía a /app/room.{code}.draw.
+ * El servidor añade el `playerId` desde el Principal autenticado (anti-spoofing),
+ * por eso aquí no aparece.
+ */
+export type DrawCommand =
+  | { type: 'STROKE'; points: { x: number; y: number }[]; color: string; thickness: number }
+  | { type: 'CLEAR' };

--- a/frontend/src/app/features/game/models/game-state.ts
+++ b/frontend/src/app/features/game/models/game-state.ts
@@ -1,0 +1,60 @@
+import { EndReason, TopVote, Winner } from './game-event';
+import { Role } from './role-assignment';
+
+export type Phase =
+  | 'CONNECTING'
+  | 'DRAWING'
+  | 'GALLERY'
+  | 'VOTING'
+  | 'TIE_BREAK'
+  | 'RESULT'
+  | 'OVER';
+
+export interface GameOverInfo {
+  winner: Winner;
+  reason: EndReason;
+  impostorId: number;
+  secretWord: string;
+}
+
+/**
+ * Estado completo del juego en el cliente, único source of truth de las
+ * sub-vistas (DrawingPhaseView, GalleryView, VotingView, ...). Se actualiza
+ * exclusivamente vía GameStateService.applyEvent / applyRoleAssignment.
+ */
+export interface GameState {
+  phase: Phase;
+  round: number;
+  drawingOrder: number[];
+  currentDrawerId: number | null;
+  timeRemainingSec: number;
+
+  myRole: Role | null;
+  secretWord: string | null;
+  hint: string | null;
+  impostorLives: number | null;
+
+  topVoted: TopVote[];
+  tiedPlayers: TopVote[];
+  eliminated: number | null;
+  wasImpostorEliminated: boolean | null;
+
+  gameOver: GameOverInfo | null;
+}
+
+export const INITIAL_STATE: GameState = {
+  phase: 'CONNECTING',
+  round: 0,
+  drawingOrder: [],
+  currentDrawerId: null,
+  timeRemainingSec: 0,
+  myRole: null,
+  secretWord: null,
+  hint: null,
+  impostorLives: null,
+  topVoted: [],
+  tiedPlayers: [],
+  eliminated: null,
+  wasImpostorEliminated: null,
+  gameOver: null,
+};

--- a/frontend/src/app/features/game/models/role-assignment.ts
+++ b/frontend/src/app/features/game/models/role-assignment.ts
@@ -1,0 +1,19 @@
+// Espejo TypeScript del sealed interface RoleAssignment del backend Track D.
+// Mantener sincronizado con:
+//   backend/src/main/java/com/impaintor/feature/realtime/dto/outbound/RoleAssignment.java
+
+export type Role = 'PAINTER' | 'IMPOSTOR';
+
+export type RoleAssignment =
+  | { type: 'ROLE_ASSIGNMENT'; role: 'PAINTER'; word: string }
+  | { type: 'ROLE_ASSIGNMENT'; role: 'IMPOSTOR'; hint: string; lives: number };
+
+/** Resultado privado de un intento de adivinación del impostor. */
+export interface GuessResult {
+  type: 'GUESS_RESULT';
+  correct: boolean;
+  livesRemaining: number;
+}
+
+/** Mensaje privado entrante en /user/queue/private — union de los anteriores. */
+export type PrivateMessage = RoleAssignment | GuessResult;

--- a/frontend/src/app/features/game/services/game-state.spec.ts
+++ b/frontend/src/app/features/game/services/game-state.spec.ts
@@ -1,0 +1,181 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { GameStateService } from './game-state';
+import { GameEvent } from '../models/game-event';
+import { RoleAssignment } from '../models/role-assignment';
+
+describe('GameStateService', () => {
+  let svc: GameStateService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    svc = TestBed.inject(GameStateService);
+  });
+
+  it('estado inicial: phase=CONNECTING y campos en valores nulos', () => {
+    const s = svc.state();
+    expect(s.phase).toBe('CONNECTING');
+    expect(s.round).toBe(0);
+    expect(s.drawingOrder).toEqual([]);
+    expect(s.currentDrawerId).toBeNull();
+    expect(s.myRole).toBeNull();
+    expect(s.secretWord).toBeNull();
+    expect(s.hint).toBeNull();
+    expect(s.impostorLives).toBeNull();
+    expect(s.gameOver).toBeNull();
+  });
+
+  describe('applyEvent', () => {
+    it('GAME_START → phase=DRAWING, round=1, drawingOrder set', () => {
+      const ev: GameEvent = { type: 'GAME_START', drawingOrder: [42, 7, 13], round: 1 };
+      svc.applyEvent(ev);
+      expect(svc.state().phase).toBe('DRAWING');
+      expect(svc.state().round).toBe(1);
+      expect(svc.state().drawingOrder).toEqual([42, 7, 13]);
+    });
+
+    it('TURN_START → currentDrawerId y timeRemainingSec set', () => {
+      svc.applyEvent({ type: 'TURN_START', playerId: 42, timeSeconds: 30 });
+      expect(svc.state().currentDrawerId).toBe(42);
+      expect(svc.state().timeRemainingSec).toBe(30);
+    });
+
+    it('TURN_END → currentDrawerId vuelve a null', () => {
+      svc.applyEvent({ type: 'TURN_START', playerId: 42, timeSeconds: 30 });
+      svc.applyEvent({ type: 'TURN_END', playerId: 42 });
+      expect(svc.state().currentDrawerId).toBeNull();
+    });
+
+    it('GALLERY_PHASE → phase=GALLERY', () => {
+      svc.applyEvent({ type: 'GALLERY_PHASE' });
+      expect(svc.state().phase).toBe('GALLERY');
+    });
+
+    it('VOTE_PHASE → phase=VOTING y timer set', () => {
+      svc.applyEvent({ type: 'VOTE_PHASE', timeSeconds: 30 });
+      expect(svc.state().phase).toBe('VOTING');
+      expect(svc.state().timeRemainingSec).toBe(30);
+    });
+
+    it('VOTE_RESULT → phase=RESULT, eliminated y topVoted set', () => {
+      svc.applyEvent({
+        type: 'VOTE_RESULT',
+        eliminated: 7,
+        wasImpostor: false,
+        topVoted: [{ id: 7, votes: 3 }],
+      });
+      expect(svc.state().phase).toBe('RESULT');
+      expect(svc.state().eliminated).toBe(7);
+      expect(svc.state().wasImpostorEliminated).toBe(false);
+      expect(svc.state().topVoted).toEqual([{ id: 7, votes: 3 }]);
+    });
+
+    it('VOTE_TIE → phase=TIE_BREAK, tiedPlayers set', () => {
+      svc.applyEvent({
+        type: 'VOTE_TIE',
+        tiedPlayers: [
+          { id: 7, votes: 3 },
+          { id: 13, votes: 3 },
+        ],
+        timeSeconds: 15,
+      });
+      expect(svc.state().phase).toBe('TIE_BREAK');
+      expect(svc.state().tiedPlayers).toHaveLength(2);
+      expect(svc.state().timeRemainingSec).toBe(15);
+    });
+
+    it('GUESS_ATTEMPT (impostor) → actualiza impostorLives y emite por gameEvents$', async () => {
+      svc.applyRoleAssignment({ type: 'ROLE_ASSIGNMENT', role: 'IMPOSTOR', hint: 'piano', lives: 1 });
+      const emitted = new Promise<GameEvent>((resolve) => {
+        svc.gameEvents$.subscribe((e) => resolve(e));
+      });
+      svc.applyEvent({ type: 'GUESS_ATTEMPT', livesRemaining: 0, correct: false });
+      const ev = await emitted;
+      expect(ev.type).toBe('GUESS_ATTEMPT');
+      expect(svc.state().impostorLives).toBe(0);
+    });
+
+    it('NEW_ROUND → round incrementado, phase=DRAWING, votes/eliminated reseteados', () => {
+      svc.applyEvent({ type: 'GAME_START', drawingOrder: [1, 2, 3], round: 1 });
+      svc.applyEvent({
+        type: 'VOTE_RESULT',
+        eliminated: 2,
+        wasImpostor: false,
+        topVoted: [{ id: 2, votes: 3 }],
+      });
+      svc.applyEvent({ type: 'NEW_ROUND', round: 2, drawingOrder: [1, 3] });
+      expect(svc.state().phase).toBe('DRAWING');
+      expect(svc.state().round).toBe(2);
+      expect(svc.state().drawingOrder).toEqual([1, 3]);
+      expect(svc.state().eliminated).toBeNull();
+      expect(svc.state().topVoted).toEqual([]);
+    });
+
+    it('GAME_OVER → phase=OVER, gameOver populado', () => {
+      svc.applyEvent({
+        type: 'GAME_OVER',
+        winner: 'PAINTERS',
+        reason: 'VOTED_OUT',
+        impostorId: 8,
+        secretWord: 'guitarra',
+      });
+      expect(svc.state().phase).toBe('OVER');
+      expect(svc.state().gameOver).toEqual({
+        winner: 'PAINTERS',
+        reason: 'VOTED_OUT',
+        impostorId: 8,
+        secretWord: 'guitarra',
+      });
+    });
+  });
+
+  describe('applyRoleAssignment', () => {
+    it('Painter → myRole=PAINTER, secretWord set, hint/lives null', () => {
+      const role: RoleAssignment = { type: 'ROLE_ASSIGNMENT', role: 'PAINTER', word: 'guitarra' };
+      svc.applyRoleAssignment(role);
+      expect(svc.state().myRole).toBe('PAINTER');
+      expect(svc.state().secretWord).toBe('guitarra');
+      expect(svc.state().hint).toBeNull();
+      expect(svc.state().impostorLives).toBeNull();
+    });
+
+    it('Impostor → myRole=IMPOSTOR, hint y impostorLives set', () => {
+      const role: RoleAssignment = { type: 'ROLE_ASSIGNMENT', role: 'IMPOSTOR', hint: 'piano', lives: 1 };
+      svc.applyRoleAssignment(role);
+      expect(svc.state().myRole).toBe('IMPOSTOR');
+      expect(svc.state().hint).toBe('piano');
+      expect(svc.state().impostorLives).toBe(1);
+      expect(svc.state().secretWord).toBeNull();
+    });
+  });
+
+  describe('selectores computed', () => {
+    it('isImpostor() refleja el rol asignado', () => {
+      expect(svc.isImpostor()).toBe(false);
+      svc.applyRoleAssignment({ type: 'ROLE_ASSIGNMENT', role: 'IMPOSTOR', hint: 'x', lives: 1 });
+      expect(svc.isImpostor()).toBe(true);
+    });
+
+    it('isMyTurn(myId) compara con currentDrawerId', () => {
+      svc.applyEvent({ type: 'TURN_START', playerId: 42, timeSeconds: 30 });
+      expect(svc.isMyTurn(42)).toBe(true);
+      expect(svc.isMyTurn(7)).toBe(false);
+    });
+
+    it('phase() expone la fase actual', () => {
+      expect(svc.phase()).toBe('CONNECTING');
+      svc.applyEvent({ type: 'GAME_START', drawingOrder: [1], round: 1 });
+      expect(svc.phase()).toBe('DRAWING');
+    });
+  });
+
+  it('reset() devuelve el estado al inicial', () => {
+    svc.applyEvent({ type: 'GAME_START', drawingOrder: [1, 2], round: 1 });
+    svc.applyRoleAssignment({ type: 'ROLE_ASSIGNMENT', role: 'PAINTER', word: 'x' });
+    svc.reset();
+    expect(svc.state().phase).toBe('CONNECTING');
+    expect(svc.state().round).toBe(0);
+    expect(svc.state().myRole).toBeNull();
+  });
+});

--- a/frontend/src/app/features/game/services/game-state.ts
+++ b/frontend/src/app/features/game/services/game-state.ts
@@ -1,0 +1,115 @@
+import { Injectable, computed, signal } from '@angular/core';
+import { Subject } from 'rxjs';
+
+import { GameEvent } from '../models/game-event';
+import { RoleAssignment } from '../models/role-assignment';
+import { GameState, INITIAL_STATE, Phase } from '../models/game-state';
+
+/**
+ * Store con signals que centraliza el estado del juego en el cliente.
+ * Único source of truth para todas las sub-vistas (DrawingPhaseView, etc).
+ *
+ * Las mutaciones solo ocurren vía applyEvent / applyRoleAssignment / reset.
+ * gameEvents$ se expone como Subject para que P6 (SFX) pueda enchufar
+ * efectos de audio sin acoplarse a la implementación de las vistas.
+ */
+@Injectable({ providedIn: 'root' })
+export class GameStateService {
+  private readonly _state = signal<GameState>(structuredClone(INITIAL_STATE));
+
+  /** Signal readonly del estado completo. */
+  readonly state = this._state.asReadonly();
+
+  /** Stream de eventos aplicados (para SFX, debugging, P6). */
+  readonly gameEvents$ = new Subject<GameEvent>();
+
+  // ── Selectores ───────────────────────────────────────────────────────────
+
+  readonly phase = computed<Phase>(() => this._state().phase);
+  readonly isImpostor = computed<boolean>(() => this._state().myRole === 'IMPOSTOR');
+  readonly hint = computed<string | null>(() => this._state().hint);
+  readonly impostorLives = computed<number | null>(() => this._state().impostorLives);
+  readonly secretWord = computed<string | null>(() => this._state().secretWord);
+
+  /** True si el id pasado es el dibujante actual. */
+  isMyTurn(myId: number): boolean {
+    return this._state().currentDrawerId === myId;
+  }
+
+  // ── Mutaciones ───────────────────────────────────────────────────────────
+
+  applyEvent(event: GameEvent): void {
+    this._state.update((s) => this.reduce(s, event));
+    this.gameEvents$.next(event);
+  }
+
+  applyRoleAssignment(role: RoleAssignment): void {
+    this._state.update((s) =>
+      role.role === 'PAINTER'
+        ? { ...s, myRole: 'PAINTER', secretWord: role.word, hint: null, impostorLives: null }
+        : { ...s, myRole: 'IMPOSTOR', hint: role.hint, impostorLives: role.lives, secretWord: null },
+    );
+  }
+
+  reset(): void {
+    this._state.set(structuredClone(INITIAL_STATE));
+  }
+
+  // ── Reducer ──────────────────────────────────────────────────────────────
+
+  private reduce(s: GameState, e: GameEvent): GameState {
+    switch (e.type) {
+      case 'GAME_START':
+        return { ...s, phase: 'DRAWING', round: e.round, drawingOrder: e.drawingOrder };
+      case 'TURN_START':
+        return { ...s, currentDrawerId: e.playerId, timeRemainingSec: e.timeSeconds };
+      case 'TURN_END':
+        return { ...s, currentDrawerId: null };
+      case 'GALLERY_PHASE':
+        return { ...s, phase: 'GALLERY' };
+      case 'VOTE_PHASE':
+        return { ...s, phase: 'VOTING', timeRemainingSec: e.timeSeconds };
+      case 'VOTE_RESULT':
+        return {
+          ...s,
+          phase: 'RESULT',
+          eliminated: e.eliminated,
+          wasImpostorEliminated: e.wasImpostor,
+          topVoted: e.topVoted,
+        };
+      case 'VOTE_TIE':
+        return { ...s, phase: 'TIE_BREAK', tiedPlayers: e.tiedPlayers, timeRemainingSec: e.timeSeconds };
+      case 'GUESS_ATTEMPT':
+        // Solo actualizamos las vidas si el jugador es impostor (los demás reciben el evento por broadcast pero no afecta su estado interno).
+        return s.myRole === 'IMPOSTOR' ? { ...s, impostorLives: e.livesRemaining } : s;
+      case 'NEW_ROUND':
+        return {
+          ...s,
+          phase: 'DRAWING',
+          round: e.round,
+          drawingOrder: e.drawingOrder,
+          currentDrawerId: null,
+          eliminated: null,
+          wasImpostorEliminated: null,
+          topVoted: [],
+          tiedPlayers: [],
+        };
+      case 'GAME_OVER':
+        return {
+          ...s,
+          phase: 'OVER',
+          gameOver: {
+            winner: e.winner,
+            reason: e.reason,
+            impostorId: e.impostorId,
+            secretWord: e.secretWord,
+          },
+        };
+      default: {
+        // Exhaustiveness check — el compilador grita si añadimos un GameEvent nuevo y olvidamos su case.
+        const _exhaustive: never = e;
+        return s;
+      }
+    }
+  }
+}

--- a/frontend/src/app/features/game/services/mock-game-event-emitter.ts
+++ b/frontend/src/app/features/game/services/mock-game-event-emitter.ts
@@ -1,0 +1,104 @@
+import { Injectable } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
+
+import { GameEvent } from '../models/game-event';
+import { RoleAssignment } from '../models/role-assignment';
+
+/**
+ * STUB DEV-ONLY — solo se usa cuando GameComponent recibe ?dev=true.
+ *
+ * Reproduce un guion fijo de eventos para que las 6 sub-vistas se vean
+ * funcionar sin necesitar Track H levantado. P3 puede usarlo durante el
+ * desarrollo de cada sub-vista; en CI nunca se ejerce.
+ *
+ * Cuando Track H mergee y emita eventos reales, este servicio sigue siendo
+ * útil como herramienta de demo offline — no hay razón para borrarlo.
+ */
+@Injectable({ providedIn: 'root' })
+export class MockGameEventEmitter {
+  private readonly events$ = new Subject<GameEvent>();
+  private readonly role$ = new Subject<RoleAssignment>();
+  private timeouts: ReturnType<typeof setTimeout>[] = [];
+
+  /** Stream de GameEvents (lo consume GameComponent en lugar del Stomp real). */
+  asObservable(): Observable<GameEvent> {
+    return this.events$.asObservable();
+  }
+
+  asRoleObservable(): Observable<RoleAssignment> {
+    return this.role$.asObservable();
+  }
+
+  /** Asigna rol painter al usuario "yo" (id=42 en el script por defecto). */
+  emitPainterAssignment(word = 'guitarra'): void {
+    this.role$.next({ type: 'ROLE_ASSIGNMENT', role: 'PAINTER', word });
+  }
+
+  /** Asigna rol impostor con la pista. */
+  emitImpostorAssignment(hint = 'piano', lives = 1): void {
+    this.role$.next({ type: 'ROLE_ASSIGNMENT', role: 'IMPOSTOR', hint, lives });
+  }
+
+  /**
+   * Reproduce el guion completo de un partido tipo (2 rondas + game over).
+   * Cada paso se separa con `delayMs` para que el cambio de fase sea visible.
+   */
+  playFullGameScript(stepDelayMs = 1500): void {
+    this.cancel();
+    const drawingOrder = [42, 7, 13];
+
+    const script: { delay: number; ev: GameEvent }[] = [
+      { delay: 0, ev: { type: 'GAME_START', drawingOrder, round: 1 } },
+      { delay: 1, ev: { type: 'TURN_START', playerId: 42, timeSeconds: 5 } },
+      { delay: 2, ev: { type: 'TURN_END', playerId: 42 } },
+      { delay: 3, ev: { type: 'TURN_START', playerId: 7, timeSeconds: 5 } },
+      { delay: 4, ev: { type: 'TURN_END', playerId: 7 } },
+      { delay: 5, ev: { type: 'TURN_START', playerId: 13, timeSeconds: 5 } },
+      { delay: 6, ev: { type: 'TURN_END', playerId: 13 } },
+      { delay: 7, ev: { type: 'GALLERY_PHASE' } },
+      { delay: 8, ev: { type: 'VOTE_PHASE', timeSeconds: 5 } },
+      {
+        delay: 9,
+        ev: {
+          type: 'VOTE_RESULT',
+          eliminated: 7,
+          wasImpostor: false,
+          topVoted: [{ id: 7, votes: 2 }],
+        },
+      },
+      { delay: 10, ev: { type: 'NEW_ROUND', round: 2, drawingOrder: [42, 13] } },
+      { delay: 11, ev: { type: 'TURN_START', playerId: 42, timeSeconds: 5 } },
+      { delay: 12, ev: { type: 'TURN_END', playerId: 42 } },
+      { delay: 13, ev: { type: 'TURN_START', playerId: 13, timeSeconds: 5 } },
+      { delay: 14, ev: { type: 'TURN_END', playerId: 13 } },
+      { delay: 15, ev: { type: 'GALLERY_PHASE' } },
+      { delay: 16, ev: { type: 'VOTE_PHASE', timeSeconds: 5 } },
+      {
+        delay: 17,
+        ev: {
+          type: 'GAME_OVER',
+          winner: 'PAINTERS',
+          reason: 'VOTED_OUT',
+          impostorId: 13,
+          secretWord: 'guitarra',
+        },
+      },
+    ];
+
+    for (const step of script) {
+      const t = setTimeout(() => this.events$.next(step.ev), step.delay * stepDelayMs);
+      this.timeouts.push(t);
+    }
+  }
+
+  /** Cancela cualquier guion en curso. Útil al destruir GameComponent. */
+  cancel(): void {
+    this.timeouts.forEach((t) => clearTimeout(t));
+    this.timeouts = [];
+  }
+
+  /** Helper test-only para emitir un evento puntual sin temporizadores. */
+  emit(event: GameEvent): void {
+    this.events$.next(event);
+  }
+}

--- a/frontend/src/app/features/game/services/spectator-canvas.spec.ts
+++ b/frontend/src/app/features/game/services/spectator-canvas.spec.ts
@@ -1,0 +1,134 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { SpectatorCanvasService } from './spectator-canvas';
+import { GameStateService } from './game-state';
+import { StrokeBroadcast, ClearCanvasBroadcast } from '../models/game-event';
+
+/**
+ * jsdom no implementa Canvas API completa. Mockeamos `getContext` para que devuelva
+ * un objeto stub con los métodos que usa el servicio. `toDataURL` se mockea con
+ * un valor determinista para verificar el flujo.
+ */
+function mockCanvasApi() {
+  const ctxStub = {
+    fillStyle: '',
+    strokeStyle: '',
+    lineCap: '',
+    lineJoin: '',
+    lineWidth: 0,
+    fillRect: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+    clearRect: vi.fn(),
+  };
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(ctxStub as unknown as CanvasRenderingContext2D);
+  vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockReturnValue('data:image/png;base64,FAKE');
+  return ctxStub;
+}
+
+describe('SpectatorCanvasService', () => {
+  let svc: SpectatorCanvasService;
+  let gameState: GameStateService;
+  let ctxStub: ReturnType<typeof mockCanvasApi>;
+
+  beforeEach(() => {
+    ctxStub = mockCanvasApi();
+    TestBed.configureTestingModule({});
+    gameState = TestBed.inject(GameStateService);
+    svc = TestBed.inject(SpectatorCanvasService);
+  });
+
+  it('snapshots inicia vacío', () => {
+    expect(svc.snapshots()).toEqual({});
+  });
+
+  it('replayStroke crea canvas off-screen y actualiza snapshots con dataUrl', () => {
+    const stroke: StrokeBroadcast = {
+      type: 'STROKE',
+      playerId: 42,
+      points: [{ x: 10, y: 10 }, { x: 20, y: 20 }],
+      color: '#FF0000',
+      thickness: 3,
+    };
+
+    svc.replayStroke(stroke);
+
+    expect(svc.snapshots()[42]).toBe('data:image/png;base64,FAKE');
+    expect(ctxStub.beginPath).toHaveBeenCalled();
+    expect(ctxStub.moveTo).toHaveBeenCalledWith(10, 10);
+    expect(ctxStub.lineTo).toHaveBeenCalledWith(20, 20);
+    expect(ctxStub.stroke).toHaveBeenCalled();
+  });
+
+  it('múltiples strokes del mismo jugador acumulan en el mismo canvas', () => {
+    svc.replayStroke({ type: 'STROKE', playerId: 7, points: [{ x: 0, y: 0 }, { x: 1, y: 1 }], color: '#000', thickness: 1 });
+    const firstSnapshot = svc.snapshots()[7];
+    svc.replayStroke({ type: 'STROKE', playerId: 7, points: [{ x: 2, y: 2 }, { x: 3, y: 3 }], color: '#000', thickness: 1 });
+
+    expect(svc.snapshots()[7]).toBeTruthy();
+    // Mismo dataUrl mockeado, pero se invocó stroke dos veces (un canvas por jugador).
+    expect(ctxStub.stroke).toHaveBeenCalledTimes(2);
+    expect(firstSnapshot).toBe(svc.snapshots()[7]); // mismo mock determinista
+  });
+
+  it('strokes de jugadores distintos generan entradas distintas en snapshots', () => {
+    svc.replayStroke({ type: 'STROKE', playerId: 1, points: [{ x: 0, y: 0 }, { x: 1, y: 1 }], color: '#000', thickness: 1 });
+    svc.replayStroke({ type: 'STROKE', playerId: 2, points: [{ x: 0, y: 0 }, { x: 1, y: 1 }], color: '#000', thickness: 1 });
+
+    expect(Object.keys(svc.snapshots())).toHaveLength(2);
+    expect(svc.snapshots()[1]).toBeTruthy();
+    expect(svc.snapshots()[2]).toBeTruthy();
+  });
+
+  it('clearPlayer borra el canvas del jugador y actualiza snapshot', () => {
+    svc.replayStroke({ type: 'STROKE', playerId: 42, points: [{ x: 0, y: 0 }, { x: 1, y: 1 }], color: '#000', thickness: 1 });
+    expect(svc.snapshots()[42]).toBeTruthy();
+
+    svc.clearPlayer(42);
+
+    expect(ctxStub.clearRect).toHaveBeenCalled();
+    // Después del clear el snapshot se actualiza al canvas vacío (mock devuelve mismo dataUrl).
+    expect(svc.snapshots()[42]).toBe('data:image/png;base64,FAKE');
+  });
+
+  it('GAME_START resetea todos los snapshots', () => {
+    svc.replayStroke({ type: 'STROKE', playerId: 1, points: [{ x: 0, y: 0 }, { x: 1, y: 1 }], color: '#000', thickness: 1 });
+    svc.replayStroke({ type: 'STROKE', playerId: 2, points: [{ x: 0, y: 0 }, { x: 1, y: 1 }], color: '#000', thickness: 1 });
+    expect(Object.keys(svc.snapshots())).toHaveLength(2);
+
+    gameState.applyEvent({ type: 'GAME_START', drawingOrder: [1, 2], round: 1 });
+
+    expect(svc.snapshots()).toEqual({});
+  });
+
+  it('NEW_ROUND resetea todos los snapshots', () => {
+    svc.replayStroke({ type: 'STROKE', playerId: 1, points: [{ x: 0, y: 0 }, { x: 1, y: 1 }], color: '#000', thickness: 1 });
+
+    gameState.applyEvent({ type: 'NEW_ROUND', round: 2, drawingOrder: [1, 3] });
+
+    expect(svc.snapshots()).toEqual({});
+  });
+
+  it('replayClear emite ClearCanvasBroadcast llamando a clearPlayer', () => {
+    svc.replayStroke({ type: 'STROKE', playerId: 42, points: [{ x: 0, y: 0 }, { x: 1, y: 1 }], color: '#000', thickness: 1 });
+    const clear: ClearCanvasBroadcast = { type: 'CLEAR', playerId: 42 };
+
+    svc.replayBroadcast(clear);
+
+    expect(ctxStub.clearRect).toHaveBeenCalled();
+  });
+
+  it('replayBroadcast despacha STROKE y CLEAR según type', () => {
+    const stroke: StrokeBroadcast = { type: 'STROKE', playerId: 1, points: [{ x: 0, y: 0 }, { x: 1, y: 1 }], color: '#000', thickness: 1 };
+    const clear: ClearCanvasBroadcast = { type: 'CLEAR', playerId: 1 };
+
+    svc.replayBroadcast(stroke);
+    expect(ctxStub.stroke).toHaveBeenCalled();
+
+    svc.replayBroadcast(clear);
+    expect(ctxStub.clearRect).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/features/game/services/spectator-canvas.ts
+++ b/frontend/src/app/features/game/services/spectator-canvas.ts
@@ -1,0 +1,121 @@
+import { Injectable, PLATFORM_ID, inject, signal } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+
+import { ClearCanvasBroadcast, DrawBroadcast, StrokeBroadcast } from '../models/game-event';
+import { GameStateService } from './game-state';
+
+const CANVAS_WIDTH = 800;
+const CANVAS_HEIGHT = 600;
+
+/**
+ * Mantiene un canvas off-screen por jugador y replays los strokes recibidos
+ * vía WebSocket. Expone `snapshots` (signal de Record<playerId, dataUrl>) que
+ * `DrawingPhaseView` (modo espectador), `VotingView` y `GalleryView` consumen
+ * con `<img [src]="snapshots()[playerId]">`.
+ *
+ * Decisión arquitectónica: ver track-i-plan.md §4.6 (Opción B).
+ *
+ * Reset: se subscribe a `gameStateService.gameEvents$` y limpia todos los
+ * canvases en `GAME_START` y `NEW_ROUND`.
+ *
+ * SSR-safe: en el servidor (no browser), todos los métodos son no-op.
+ */
+@Injectable({ providedIn: 'root' })
+export class SpectatorCanvasService {
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly gameState = inject(GameStateService);
+
+  private readonly canvases = new Map<number, HTMLCanvasElement>();
+  private readonly _snapshots = signal<Record<number, string>>({});
+
+  /** Signal readonly de snapshots por jugador. */
+  readonly snapshots = this._snapshots.asReadonly();
+
+  constructor() {
+    // Reset automático al inicio de partida o ronda nueva.
+    this.gameState.gameEvents$.subscribe((ev) => {
+      if (ev.type === 'GAME_START' || ev.type === 'NEW_ROUND') {
+        this.resetAll();
+      }
+    });
+  }
+
+  /** Replays un stroke en el canvas del jugador y actualiza snapshot. */
+  replayStroke(stroke: StrokeBroadcast): void {
+    if (!isPlatformBrowser(this.platformId)) return;
+
+    const canvas = this.getOrCreateCanvas(stroke.playerId);
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    ctx.strokeStyle = stroke.color;
+    ctx.lineWidth = stroke.thickness;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+
+    if (stroke.points.length === 0) return;
+    ctx.beginPath();
+    const [first, ...rest] = stroke.points;
+    ctx.moveTo(first.x, first.y);
+    for (const p of rest) {
+      ctx.lineTo(p.x, p.y);
+    }
+    ctx.stroke();
+
+    this.updateSnapshot(stroke.playerId, canvas);
+  }
+
+  /** Limpia el canvas del jugador y actualiza snapshot. */
+  clearPlayer(playerId: number): void {
+    if (!isPlatformBrowser(this.platformId)) return;
+
+    const canvas = this.canvases.get(playerId);
+    if (!canvas) return;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    ctx.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+    this.updateSnapshot(playerId, canvas);
+  }
+
+  /** Despacha un broadcast (STROKE o CLEAR) al método correspondiente. */
+  replayBroadcast(broadcast: DrawBroadcast): void {
+    if (broadcast.type === 'STROKE') {
+      this.replayStroke(broadcast);
+    } else {
+      this.clearOnly(broadcast);
+    }
+  }
+
+  private clearOnly(_clear: ClearCanvasBroadcast): void {
+    this.clearPlayer(_clear.playerId);
+  }
+
+  /** Resetea todos los canvases (snapshots → {}). */
+  private resetAll(): void {
+    this.canvases.clear();
+    this._snapshots.set({});
+  }
+
+  private getOrCreateCanvas(playerId: number): HTMLCanvasElement {
+    let canvas = this.canvases.get(playerId);
+    if (!canvas) {
+      canvas = document.createElement('canvas');
+      canvas.width = CANVAS_WIDTH;
+      canvas.height = CANVAS_HEIGHT;
+      const ctx = canvas.getContext('2d');
+      if (ctx) {
+        ctx.fillStyle = '#FFFFFF';
+        ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+      }
+      this.canvases.set(playerId, canvas);
+    }
+    return canvas;
+  }
+
+  private updateSnapshot(playerId: number, canvas: HTMLCanvasElement): void {
+    const dataUrl = canvas.toDataURL('image/png');
+    this._snapshots.update((current) => ({ ...current, [playerId]: dataUrl }));
+  }
+}

--- a/frontend/src/app/features/realtime/models/stomp.ts
+++ b/frontend/src/app/features/realtime/models/stomp.ts
@@ -1,0 +1,12 @@
+// PENDING — Track F (Lobby + WebSocketService) absorberá estos modelos.
+
+export type ConnectionStatus = 'IDLE' | 'CONNECTING' | 'CONNECTED' | 'DISCONNECTED' | 'ERROR';
+
+export interface StompConfig {
+  /** URL completa del endpoint STOMP, ej: 'ws://localhost:8080/ws' o '/ws' relativo. */
+  url: string;
+  /** Token JWT crudo (sin el prefijo "Bearer "). */
+  jwt: string;
+  /** Delay constante de reconexión en ms (default 5000). */
+  reconnectDelayMs?: number;
+}

--- a/frontend/src/app/features/realtime/services/stomp-client.spec.ts
+++ b/frontend/src/app/features/realtime/services/stomp-client.spec.ts
@@ -1,0 +1,165 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { firstValueFrom, take, toArray } from 'rxjs';
+
+import { StompClientService } from './stomp-client';
+
+// Mock del módulo @stomp/stompjs — clase mock que sí soporta `new`.
+const mockClientInstances: any[] = [];
+
+vi.mock('@stomp/stompjs', () => {
+  class MockClient {
+    config: any;
+    active = false;
+    connectHeaders: Record<string, string>;
+    onConnect: ((frame: unknown) => void) | null;
+    onStompError: ((frame: unknown) => void) | null;
+    onWebSocketClose: ((evt: unknown) => void) | null;
+    activate: ReturnType<typeof vi.fn>;
+    deactivate: ReturnType<typeof vi.fn>;
+    publish: ReturnType<typeof vi.fn>;
+    subscribe: ReturnType<typeof vi.fn>;
+    _subs = new Map<string, (frame: { body: string }) => void>();
+
+    constructor(config: any) {
+      this.config = config;
+      this.connectHeaders = config?.connectHeaders ?? {};
+      this.onConnect = config?.onConnect ?? null;
+      this.onStompError = config?.onStompError ?? null;
+      this.onWebSocketClose = config?.onWebSocketClose ?? null;
+
+      this.activate = vi.fn(() => {
+        this.active = true;
+        queueMicrotask(() => this.onConnect && this.onConnect({}));
+      });
+      this.deactivate = vi.fn(() => {
+        this.active = false;
+      });
+      this.publish = vi.fn();
+      this.subscribe = vi.fn((dest: string, cb: (frame: { body: string }) => void) => {
+        this._subs.set(dest, cb);
+        return { id: dest, unsubscribe: vi.fn() };
+      });
+
+      mockClientInstances.push(this);
+    }
+  }
+  return { Client: MockClient };
+});
+
+describe('StompClientService', () => {
+  let svc: StompClientService;
+
+  beforeEach(() => {
+    mockClientInstances.length = 0;
+    TestBed.configureTestingModule({});
+    svc = TestBed.inject(StompClientService);
+  });
+
+  afterEach(() => {
+    svc.disconnect();
+    vi.clearAllMocks();
+  });
+
+  it('connect() instancia un Client con Authorization Bearer y dispara activate', async () => {
+    svc.connect({ url: '/ws', jwt: 'my-token' });
+
+    expect(mockClientInstances).toHaveLength(1);
+    const client = mockClientInstances[0];
+    expect(client.connectHeaders.Authorization).toBe('Bearer my-token');
+    expect(client.activate).toHaveBeenCalledOnce();
+  });
+
+  it('status$ emite CONNECTING y luego CONNECTED', async () => {
+    const statusPromise = firstValueFrom(svc.status$.pipe(take(3), toArray()));
+    svc.connect({ url: '/ws', jwt: 't' });
+    const states = await statusPromise;
+    expect(states).toEqual(['IDLE', 'CONNECTING', 'CONNECTED']);
+  });
+
+  it('subscribe<T>() devuelve Observable que parsea JSON del frame', async () => {
+    svc.connect({ url: '/ws', jwt: 't' });
+    await new Promise((r) => queueMicrotask(() => r(null)));
+
+    const received: any[] = [];
+    svc.subscribe<{ type: string }>('/topic/test').subscribe((msg) => received.push(msg));
+
+    const client = mockClientInstances[0];
+    expect(client.subscribe).toHaveBeenCalledWith('/topic/test', expect.any(Function));
+
+    // Emitimos un frame STOMP simulado.
+    const cb = client._subs.get('/topic/test');
+    cb({ body: JSON.stringify({ type: 'GAME_START' }) });
+
+    expect(received).toEqual([{ type: 'GAME_START' }]);
+  });
+
+  it('send() invoca client.publish con body serializado', async () => {
+    svc.connect({ url: '/ws', jwt: 't' });
+    await new Promise((r) => queueMicrotask(() => r(null)));
+
+    svc.send('/app/room.X.draw', { type: 'STROKE', points: [] });
+    const client = mockClientInstances[0];
+    expect(client.publish).toHaveBeenCalledWith({
+      destination: '/app/room.X.draw',
+      body: JSON.stringify({ type: 'STROKE', points: [] }),
+    });
+  });
+
+  it('subscribe() antes de CONNECT no se pierde — se aplica al conectar', async () => {
+    svc.connect({ url: '/ws', jwt: 't' });
+    // Subscribe inmediatamente, ANTES de que onConnect se dispare (sin await).
+    const received: any[] = [];
+    svc.subscribe<{ type: string }>('/topic/test').subscribe((msg) => received.push(msg));
+
+    const client = mockClientInstances[0];
+    // En este punto la suscripción no debería haberse delegado al cliente todavía
+    // (aún no estaba CONNECTED). Está encolada.
+    expect(client.subscribe).not.toHaveBeenCalled();
+
+    // Esperamos al onConnect (microtask que activate dispara).
+    await new Promise((r) => queueMicrotask(() => r(null)));
+
+    // Tras conectar, la suscripción debe haberse aplicado.
+    expect(client.subscribe).toHaveBeenCalledWith('/topic/test', expect.any(Function));
+
+    // Y los frames entrantes llegan al observable original.
+    const cb = client._subs.get('/topic/test')!;
+    cb({ body: JSON.stringify({ type: 'GAME_START' }) });
+    expect(received).toEqual([{ type: 'GAME_START' }]);
+  });
+
+  it('subscribe() después de CONNECT se aplica inmediatamente', async () => {
+    svc.connect({ url: '/ws', jwt: 't' });
+    await new Promise((r) => queueMicrotask(() => r(null)));
+
+    svc.subscribe<{ type: string }>('/topic/late').subscribe();
+
+    const client = mockClientInstances[0];
+    expect(client.subscribe).toHaveBeenCalledWith('/topic/late', expect.any(Function));
+  });
+
+  it('unsubscribe en una sub pendiente la cancela antes de aplicarse', async () => {
+    svc.connect({ url: '/ws', jwt: 't' });
+    const sub = svc.subscribe<{ type: string }>('/topic/cancelled').subscribe();
+    sub.unsubscribe();
+
+    await new Promise((r) => queueMicrotask(() => r(null)));
+
+    const client = mockClientInstances[0];
+    // Cancelada antes del CONNECT, nunca se delegó al cliente.
+    expect(client.subscribe).not.toHaveBeenCalled();
+  });
+
+  it('disconnect() invoca client.deactivate y emite DISCONNECTED', async () => {
+    svc.connect({ url: '/ws', jwt: 't' });
+    await new Promise((r) => queueMicrotask(() => r(null)));
+
+    svc.disconnect();
+    const client = mockClientInstances[0];
+    expect(client.deactivate).toHaveBeenCalled();
+
+    const status = await firstValueFrom(svc.status$);
+    expect(status).toBe('DISCONNECTED');
+  });
+});

--- a/frontend/src/app/features/realtime/services/stomp-client.ts
+++ b/frontend/src/app/features/realtime/services/stomp-client.ts
@@ -1,0 +1,162 @@
+import { Injectable, PLATFORM_ID, inject } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { Client, IMessage, StompSubscription } from '@stomp/stompjs';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+import { ConnectionStatus, StompConfig } from '../models/stomp';
+
+/**
+ * PENDING — Track F (Lobby + WebSocketService) absorberá este servicio.
+ *
+ * Wrapper mínimo sobre @stomp/stompjs que aporta:
+ *  - signals/observables de estado de conexión
+ *  - subscribe/send tipados con parsing JSON automático
+ *  - cola de suscripciones cuando se llaman antes de CONNECT
+ *  - SSR-safe: no hace nada si no estamos en browser
+ *
+ * Cuando F mergee su WebSocketService, GameComponent solo cambia el import.
+ */
+@Injectable({ providedIn: 'root' })
+export class StompClientService {
+  private readonly platformId = inject(PLATFORM_ID);
+
+  private client: Client | null = null;
+  private readonly _status$ = new BehaviorSubject<ConnectionStatus>('IDLE');
+
+  /**
+   * Suscripciones que se solicitaron antes de que el cliente estuviera CONNECTED.
+   * Se aplican en orden cuando llega `onConnect`.
+   */
+  private readonly pendingSubs: Array<{
+    destination: string;
+    handler: (frame: IMessage) => void;
+    cancelled: boolean;
+    bound?: StompSubscription;
+  }> = [];
+
+  /** Observable del estado de conexión. */
+  readonly status$: Observable<ConnectionStatus> = this._status$.asObservable();
+
+  connect(config: StompConfig): void {
+    if (!isPlatformBrowser(this.platformId)) {
+      // SSR safety — no se conecta en el render del servidor.
+      return;
+    }
+    if (this.client?.active) {
+      return;
+    }
+
+    this._status$.next('CONNECTING');
+
+    this.client = new Client({
+      brokerURL: this.resolveUrl(config.url),
+      connectHeaders: { Authorization: `Bearer ${config.jwt}` },
+      reconnectDelay: config.reconnectDelayMs ?? 5_000,
+      onConnect: () => {
+        this._status$.next('CONNECTED');
+        this.flushPendingSubs();
+      },
+      onStompError: () => this._status$.next('ERROR'),
+      onWebSocketClose: () => {
+        if (this._status$.value !== 'DISCONNECTED') {
+          this._status$.next('ERROR');
+        }
+      },
+    });
+
+    this.client.activate();
+  }
+
+  /**
+   * Suscribe a un destino STOMP y emite los payloads JSON parseados.
+   * Si todavía no estamos CONNECTED, la suscripción se encola y se aplica al
+   * recibir `onConnect`. Cancelar el observable antes del CONNECT cancela la
+   * suscripción pendiente.
+   */
+  subscribe<T>(destination: string): Observable<T> {
+    return new Observable<T>((subscriber) => {
+      const handler = (frame: IMessage) => {
+        try {
+          subscriber.next(JSON.parse(frame.body) as T);
+        } catch (e) {
+          subscriber.error(e);
+        }
+      };
+
+      // Si la conexión STOMP ya está establecida, suscribirse directamente.
+      // Se usa el status real (CONNECTED) en vez de client.active, porque
+      // active=true desde antes del handshake (ej: mientras reconecta).
+      if (this.client && this._status$.value === 'CONNECTED') {
+        try {
+          const sub = this.client.subscribe(destination, handler);
+          return () => sub?.unsubscribe();
+        } catch (e) {
+          subscriber.error(e);
+          return;
+        }
+      }
+
+      // En otro caso, encolar la suscripción y aplicarla al CONNECT.
+      const pending: (typeof this.pendingSubs)[number] = {
+        destination,
+        handler,
+        cancelled: false,
+      };
+      this.pendingSubs.push(pending);
+      return () => {
+        pending.cancelled = true;
+        pending.bound?.unsubscribe();
+      };
+    });
+  }
+
+  /** Publica un mensaje al destino /app/... del servidor. */
+  send<T>(destination: string, body: T): void {
+    if (!this.client?.active) {
+      return;
+    }
+    this.client.publish({
+      destination,
+      body: JSON.stringify(body),
+    });
+  }
+
+  disconnect(): void {
+    if (!this.client) {
+      return;
+    }
+    this.client.deactivate();
+    this.client = null;
+    this.pendingSubs.length = 0;
+    this._status$.next('DISCONNECTED');
+  }
+
+  private flushPendingSubs(): void {
+    if (!this.client?.active) return;
+    while (this.pendingSubs.length > 0) {
+      const pending = this.pendingSubs.shift()!;
+      if (pending.cancelled) continue;
+      try {
+        pending.bound = this.client.subscribe(pending.destination, pending.handler);
+      } catch {
+        // Si subscribe falla, la marcamos cancelada para no reintentar.
+        pending.cancelled = true;
+      }
+    }
+  }
+
+  /**
+   * Convierte una URL relativa (ej: '/ws') a absoluta usando la location actual.
+   * En browser; los tests pasan URLs absolutas de mock.
+   */
+  private resolveUrl(url: string): string {
+    if (url.startsWith('ws://') || url.startsWith('wss://')) {
+      return url;
+    }
+    if (typeof window === 'undefined') {
+      return url;
+    }
+    const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    return `${proto}//${window.location.host}${url.startsWith('/') ? url : '/' + url}`;
+  }
+}


### PR DESCRIPTION
## Resumen

Implementación de **Track I (Flujo del juego, Fase 2 — parte P4)** sobre la infraestructura WebSocket de Track D. El PR integra ahora limpiamente con los avances mergeados a `dev`: Track A (auth + `User` real), Track B (rooms), Track C (word groups) y los scaffolds de Tracks E/F/G.

## Cambios principales

- **Foundation Track I**: modelos TypeScript espejo de los DTOs del backend, `GameStateService` con signals + reducer exhaustivo, `StompClientService` wrapper de `@stomp/stompjs` (SSR-safe, con cola de subs pendientes para evitar race con `onConnect`), `MockGameEventEmitter` para demo offline (`?dev=true`), helper de auth temporal en `core/auth/token.ts`.
- **Container `GameComponent` (2I.1)**: máquina de estados con `@switch`, routing lazy `/room/:code/game`, slot `<ng-content>` para 2I.8 de P6.
- **3 vistas reales P4**:
  - `DrawingPhaseView` (2I.2) — canvas activo si PAINTER y mi turno; modo espectador con `<img>` en otro caso; subscribe a `CanvasService.getStrokeEmitter()` y reenvía `STROKE`/`CLEAR` al backend via `@Output drawCommand`; caja de adivinación inline como fallback hasta P6 entregue 2I.8.
  - `VotingView` (2I.4) — grid de tarjetas con miniaturas del `SpectatorCanvasService`, marca la tarjeta propia con `(Tú)`, lock tras voto, excluye eliminados.
  - `GameOverView` (2I.7) — reveal de palabra/pista/impostor/rondas, traducción humana de `EndReason`, botón "jugar otra vez" navega a `/`.
- **`SpectatorCanvasService`**: cierra el gap §4.6 del plan con la **Opción B** (servicio dedicado, `GameStateService` queda puro). Mantiene `HTMLCanvasElement` off-screen por jugador, expone `snapshots` signal, reset auto en `GAME_START`/`NEW_ROUND`.
- **3 placeholders** (`GalleryView`, `TieBreakView`, `VoteResultView`) listos para P3 sustituir con TDD; el container ya los enchufa.

## Cambios fruto del merge `dev` (integración Track A)

- **`jwt.secret` unificado** entre Track A (`JwtService`) y Track D (`JwtTokenValidator`): bloque raíz `jwt: { secret, expiration-ms }` en `application.yml` + `application-test.yml`, y `impaintor.realtime.jwt.secret: ${jwt.secret}` para que ambos firmen/validen con la misma clave.
- **`SecurityConfig` de Track A**: añadido `.requestMatchers("/ws/**").permitAll()` con comentario — el handshake HTTP del WebSocket no debe pasar por filtros de auth porque el JWT se valida en el frame STOMP CONNECT (`JwtChannelInterceptor`).
- **Stub `User.java` eliminado**: Track A trajo el `@Entity User` real con `@Builder`, `@PrePersist` y todos los campos de CLAUDE.md sec 4.1. Mi stub provisional ya no es necesario y se borró.

## Estado

- ✅ **Backend** `./mvnw test`: 39/39 verdes (Track D + Track A + B + C conviviendo).
- ✅ **Frontend** `npm test`: 86/86 míos verdes. 2 rojos preexistentes **ajenos a este PR**: `app.spec.ts` (scaffold heredado que espera `Hello, frontend`) y `lobby.spec.ts` de Track F (le falta provider de `ActivatedRoute` en TestBed).
- ✅ **`npm run build`** OK. Lazy chunk `game` = 40 kB. Warnings de tamaño CSS son de componentes de Tracks E/F, no míos.
- 🟡 `GalleryView`, `TieBreakView`, `VoteResultView` siguen como placeholders visuales .
- ⏸️ `core/auth/token.ts` y `StompClientService` marcados `PENDING` para Tracks E y F. Los absorberán al merge sin tocar el resto.

## Test plan

- [ ] `cd backend && ./mvnw test` → 39/39 verdes.
- [ ] `cd frontend && npm test` → 86/86 míos verdes (los 2 fallos preexistentes son ajenos).
- [ ] `cd frontend && npm run build` → bundle producción sin errores nuevos.
- [ ] **Demo offline:** `npm start` y abrir `http://localhost:4200/room/TEST/game?dev=true` — secuencia automática del `MockGameEventEmitter` muestra Drawing → Gallery (placeholder) → Voting → Result (placeholder) → … → Game Over.
- [ ] **Smoke test integrado (opcional, requiere backend up):** `docker-compose up` + `npm start`; en el navegador `localStorage.setItem('jwt', '<token-firmado-con-jwt.secret>')` e ir a `/room/TEST/game` — la conexión WebSocket abre, `JwtChannelInterceptor` valida el token y queda esperando eventos de Track H (que aún no existe).