### PR TITLE
Track J - Matchmaking Fase 3, Tareas 3J.1, 3J.2 y 3J.3

### DIFF
--- a/backend/src/main/java/com/impaintor/ImpaintorApplication.java
+++ b/backend/src/main/java/com/impaintor/ImpaintorApplication.java
@@ -3,9 +3,11 @@ package com.impaintor;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableScheduling
 public class ImpaintorApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/impaintor/feature/matchmaking/MatchmakingScheduler.java
+++ b/backend/src/main/java/com/impaintor/feature/matchmaking/MatchmakingScheduler.java
@@ -1,0 +1,18 @@
+package com.impaintor.feature.matchmaking;
+
+import com.impaintor.feature.matchmaking.service.MatchmakingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MatchmakingScheduler {
+
+    private final MatchmakingService matchmakingService;
+
+    @Scheduled(fixedRate = 2000)
+    public void runMatchmaking() {
+        matchmakingService.tryFormMatches();
+    }
+}

--- a/backend/src/main/java/com/impaintor/feature/matchmaking/MatchmakingSessionListener.java
+++ b/backend/src/main/java/com/impaintor/feature/matchmaking/MatchmakingSessionListener.java
@@ -1,0 +1,42 @@
+package com.impaintor.feature.matchmaking;
+
+import com.impaintor.feature.matchmaking.service.MatchmakingService;
+import com.impaintor.feature.realtime.security.StompPrincipal;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectedEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MatchmakingSessionListener {
+
+    private final MatchmakingService matchmakingService;
+
+    // sessionId → userId, populated on STOMP CONNECT, cleaned up on disconnect.
+    private final ConcurrentHashMap<String, Long> sessionUserMap = new ConcurrentHashMap<>();
+
+    @EventListener
+    public void onSessionConnected(SessionConnectedEvent event) {
+        if (!(event.getUser() instanceof StompPrincipal principal)) return;
+
+        String sessionId = StompHeaderAccessor.wrap(event.getMessage()).getSessionId();
+        if (sessionId == null) return;
+
+        sessionUserMap.put(sessionId, principal.user().id());
+    }
+
+    @EventListener
+    public void onSessionDisconnected(SessionDisconnectEvent event) {
+        Long userId = sessionUserMap.remove(event.getSessionId());
+        if (userId == null) return;
+
+        matchmakingService.leave(userId);
+        log.debug("Player {} removed from matchmaking queue on WebSocket disconnect", userId);
+    }
+}

--- a/backend/src/main/java/com/impaintor/feature/matchmaking/controller/MatchmakingController.java
+++ b/backend/src/main/java/com/impaintor/feature/matchmaking/controller/MatchmakingController.java
@@ -1,0 +1,38 @@
+package com.impaintor.feature.matchmaking.controller;
+
+import com.impaintor.feature.auth.config.AppUserDetails;
+import com.impaintor.feature.matchmaking.dto.MatchmakingStatusResponse;
+import com.impaintor.feature.matchmaking.service.MatchmakingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/matchmaking")
+@RequiredArgsConstructor
+public class MatchmakingController {
+
+    private final MatchmakingService matchmakingService;
+
+    @PostMapping("/queue")
+    public MatchmakingStatusResponse joinQueue(@AuthenticationPrincipal AppUserDetails currentUser) {
+        return matchmakingService.join(currentUser.getId());
+    }
+
+    @DeleteMapping("/queue")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void leaveQueue(@AuthenticationPrincipal AppUserDetails currentUser) {
+        matchmakingService.leave(currentUser.getId());
+    }
+
+    @GetMapping("/status")
+    public MatchmakingStatusResponse getStatus(@AuthenticationPrincipal AppUserDetails currentUser) {
+        return matchmakingService.getStatus(currentUser.getId());
+    }
+}

--- a/backend/src/main/java/com/impaintor/feature/matchmaking/dto/MatchmakingStatusResponse.java
+++ b/backend/src/main/java/com/impaintor/feature/matchmaking/dto/MatchmakingStatusResponse.java
@@ -1,0 +1,3 @@
+package com.impaintor.feature.matchmaking.dto;
+
+public record MatchmakingStatusResponse(boolean queued, long waitSeconds, int searchRange) {}

--- a/backend/src/main/java/com/impaintor/feature/matchmaking/models/QueueEntry.java
+++ b/backend/src/main/java/com/impaintor/feature/matchmaking/models/QueueEntry.java
@@ -1,0 +1,5 @@
+package com.impaintor.feature.matchmaking.models;
+
+import java.time.Instant;
+
+public record QueueEntry(Long userId, int elo, Instant joinedAt) {}

--- a/backend/src/main/java/com/impaintor/feature/matchmaking/service/MatchmakingService.java
+++ b/backend/src/main/java/com/impaintor/feature/matchmaking/service/MatchmakingService.java
@@ -1,0 +1,133 @@
+package com.impaintor.feature.matchmaking.service;
+
+import com.impaintor.feature.matchmaking.dto.MatchmakingStatusResponse;
+import com.impaintor.feature.matchmaking.models.QueueEntry;
+import com.impaintor.feature.realtime.dto.outbound.MatchFoundNotification;
+import com.impaintor.feature.realtime.service.RealtimePublisher;
+import com.impaintor.feature.room.models.Room;
+import com.impaintor.feature.room.repository.RoomRepository;
+import com.impaintor.feature.room.utilities.RandomGenerations;
+import com.impaintor.feature.user.models.User;
+import com.impaintor.feature.user.repository.UserRepository;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MatchmakingService {
+
+    private static final int BASE_RANGE = 50;
+    private static final int RANGE_EXPANSION_STEP = 100;
+    private static final int EXPANSION_INTERVAL_SECONDS = 10;
+    private static final int MATCH_SIZE = 5;
+
+    private final UserRepository userRepository;
+    private final RoomRepository roomRepository;
+    private final RealtimePublisher realtimePublisher;
+
+    // Inline-initialized so @RequiredArgsConstructor does not include it as a constructor arg.
+    private final ConcurrentHashMap<Long, QueueEntry> queue = new ConcurrentHashMap<>();
+
+    // --- Public queue API (called by MatchmakingController) ---
+
+    /** Idempotent: re-joining preserves the original entry (keeps wait time and ELO snapshot). */
+    public MatchmakingStatusResponse join(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        queue.computeIfAbsent(userId, id -> new QueueEntry(id, user.getElo(), Instant.now()));
+        return getStatus(userId);
+    }
+
+    public void leave(Long userId) {
+        queue.remove(userId);
+    }
+
+    public MatchmakingStatusResponse getStatus(Long userId) {
+        QueueEntry entry = queue.get(userId);
+        if (entry == null) {
+            return new MatchmakingStatusResponse(false, 0, 0);
+        }
+        long waitSeconds = ChronoUnit.SECONDS.between(entry.joinedAt(), Instant.now());
+        return new MatchmakingStatusResponse(true, waitSeconds, searchRangeFor(entry));
+    }
+
+    // --- Matching loop (called by MatchmakingScheduler every 2 s) ---
+
+    public void tryFormMatches() {
+        boolean matchFormed;
+        do {
+            matchFormed = tryFormOneMatch();
+        } while (matchFormed);
+    }
+
+    private boolean tryFormOneMatch() {
+        List<QueueEntry> sorted = new ArrayList<>(queue.values());
+        if (sorted.size() < MATCH_SIZE) return false;
+
+        sorted.sort(Comparator.comparingInt(QueueEntry::elo));
+
+        for (int i = 0; i <= sorted.size() - MATCH_SIZE; i++) {
+            List<QueueEntry> window = new ArrayList<>(sorted.subList(i, i + MATCH_SIZE));
+
+            int spread = window.get(MATCH_SIZE - 1).elo() - window.get(0).elo();
+            int tightestRange = window.stream()
+                    .mapToInt(this::searchRangeFor)
+                    .min()
+                    .orElse(0);
+
+            if (spread <= tightestRange) {
+                window.forEach(e -> queue.remove(e.userId()));
+                try {
+                    createRankedRoom(window);
+                    return true;
+                } catch (Exception ex) {
+                    log.error("Failed to create ranked room for {} players, re-queuing", window.size(), ex);
+                    // Restore entries with original joinedAt so players keep their wait time.
+                    window.forEach(e -> queue.putIfAbsent(e.userId(), e));
+                    return false;
+                }
+            }
+        }
+        return false;
+    }
+
+    private void createRankedRoom(List<QueueEntry> group) {
+        List<User> users = group.stream()
+                .map(e -> userRepository.findById(e.userId())
+                        .orElseThrow(() -> new IllegalStateException("User " + e.userId() + " vanished before room creation")))
+                .toList();
+
+        String code = RandomGenerations.CodifyRoomId(RandomGenerations.RoomRandomId());
+        Room room = new Room();
+        room.setId(code);
+        room.setRoomCode(code);
+        room.setMode(Room.Mode.RANKED);
+        room.setSize(MATCH_SIZE);
+        room.setGameState(Room.GameState.WAITING);
+        room.setPlayersNames(new ArrayList<>(users));
+        roomRepository.save(room);
+
+        MatchFoundNotification notification = new MatchFoundNotification(code);
+        users.forEach(u -> realtimePublisher.sendMatchFound(u.getId(), notification));
+
+        log.info("Ranked room {} created for players {}", code,
+                users.stream().map(User::getId).toList());
+    }
+
+    // Package-visible for MatchmakingScheduler tests and future 3J.5 integrations.
+    // Range starts at ±50 and expands by ±100 every 10 seconds.
+    int searchRangeFor(QueueEntry entry) {
+        long waited = ChronoUnit.SECONDS.between(entry.joinedAt(), Instant.now());
+        return BASE_RANGE + (int) (waited / EXPANSION_INTERVAL_SECONDS) * RANGE_EXPANSION_STEP;
+    }
+}

--- a/backend/src/main/java/com/impaintor/feature/realtime/dto/outbound/MatchFoundNotification.java
+++ b/backend/src/main/java/com/impaintor/feature/realtime/dto/outbound/MatchFoundNotification.java
@@ -1,0 +1,12 @@
+package com.impaintor.feature.realtime.dto.outbound;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record MatchFoundNotification(
+        @JsonProperty("type") String type,
+        @JsonProperty("roomCode") String roomCode
+) {
+    public MatchFoundNotification(String roomCode) {
+        this("MATCH_FOUND", roomCode);
+    }
+}

--- a/backend/src/main/java/com/impaintor/feature/realtime/service/RealtimePublisher.java
+++ b/backend/src/main/java/com/impaintor/feature/realtime/service/RealtimePublisher.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import com.impaintor.feature.realtime.dto.outbound.ClearCanvasBroadcast;
 import com.impaintor.feature.realtime.dto.outbound.GameEvent;
 import com.impaintor.feature.realtime.dto.outbound.GuessResult;
+import com.impaintor.feature.realtime.dto.outbound.MatchFoundNotification;
 import com.impaintor.feature.realtime.dto.outbound.RoleAssignment;
 import com.impaintor.feature.realtime.dto.outbound.StrokeBroadcast;
 
@@ -45,5 +46,9 @@ public class RealtimePublisher {
 
     public void sendGuessResult(Long userId, GuessResult result) {
         messaging.convertAndSendToUser(String.valueOf(userId), PRIVATE_QUEUE, result);
+    }
+
+    public void sendMatchFound(Long userId, MatchFoundNotification notification) {
+        messaging.convertAndSendToUser(String.valueOf(userId), PRIVATE_QUEUE, notification);
     }
 }


### PR DESCRIPTION
**Archivos creados:**

- `feature/matchmaking/models/QueueEntry.java` — Record inmutable que representa a un jugador en cola: ID de usuario, ELO (capturado al entrar) y marca de tiempo de entrada.
- `feature/matchmaking/dto/MatchmakingStatusResponse.java` — DTO de respuesta para los endpoints REST: estado en cola, segundos de espera y rango de búsqueda actual.
- `feature/matchmaking/service/MatchmakingService.java` — Núcleo del sistema: cola en memoria (`ConcurrentHashMap`), lógica de unirse/salir/consultar estado, cálculo de rango ELO expansivo, algoritmo de ventana deslizante para formar partidas y creación de salas ranked.
- `feature/matchmaking/controller/MatchmakingController.java` — Tres endpoints REST: `POST /api/matchmaking/queue` (unirse), `DELETE /api/matchmaking/queue` (salir), `GET /api/matchmaking/status` (consultar estado).
- `feature/matchmaking/MatchmakingScheduler.java` — Tarea programada con `@Scheduled(fixedRate = 2000)` que invoca el emparejamiento cada 2 segundos.
- `feature/matchmaking/MatchmakingSessionListener.java` — Escucha eventos del ciclo de vida STOMP (`SessionConnectedEvent`, `SessionDisconnectEvent`) para eliminar automáticamente de la cola a jugadores que pierden la conexión WebSocket.
- `feature/realtime/dto/outbound/MatchFoundNotification.java` — Mensaje WebSocket privado enviado a cada jugador emparejado con el código de sala.

**Archivos modificados:**

- `feature/realtime/service/RealtimePublisher.java` — Añadido método `sendMatchFound` para enviar la notificación de partida encontrada por el canal privado `/user/queue/private`.
- `ImpaintorApplication.java` — Añadida la anotación `@EnableScheduling` para activar las tareas programadas.