### PR TITLE
Chore UI consistency

### DIFF
--- a/frontend/src/app/features/game/components/canvas/canvas.html
+++ b/frontend/src/app/features/game/components/canvas/canvas.html
@@ -53,11 +53,6 @@
         </button>
       </div>
     </div>
-    <!-- Info palabra (opcional) -->
-    <div class="tool-section word-display" *ngIf="showWord">
-      <label>Palabra:</label>
-      <span class="word-badge">{{showWord}}</span>
-    </div>
   </div>
 
   <!-- Canvas -->

--- a/frontend/src/app/features/game/components/drawing-phase-view/drawing-phase-view.css
+++ b/frontend/src/app/features/game/components/drawing-phase-view/drawing-phase-view.css
@@ -1,8 +1,6 @@
 .drawing-phase {
-  background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
-  padding: 1.25rem;
+  max-width: 900px;
+  margin: 0 auto;
 }
 
 .phase-header {
@@ -14,38 +12,33 @@
 
 .phase-header h2 {
   margin: 0;
-  font-size: 1.25rem;
-  color: #333;
+  font-family: 'Cinzel', serif;
+  font-size: 1.15rem;
+  color: #c9a86c;
+  letter-spacing: 0.04em;
 }
 
 .timer {
   font-variant-numeric: tabular-nums;
-  font-weight: 600;
-  background: #2563eb;
-  color: white;
-  padding: 0.25rem 0.75rem;
+  font-weight: 700;
+  background: rgba(201, 168, 108, 0.12);
+  border: 1px solid #c9a86c;
+  color: #c9a86c;
+  padding: 0.25rem 0.85rem;
   border-radius: 999px;
-  font-size: 0.875rem;
+  font-size: 0.9rem;
+  font-family: 'Nunito', sans-serif;
 }
 
 .word-banner.painter {
-  background: #ecfdf5;
-  border: 1px solid #10b981;
-  padding: 0.75rem 1rem;
+  background: rgba(82, 183, 136, 0.12);
+  border: 1px solid rgba(82, 183, 136, 0.5);
+  color: #7de8b0;
+  padding: 0.6rem 1rem;
   border-radius: 6px;
   margin-bottom: 1rem;
   font-size: 1.05rem;
-}
-
-.hint-banner.impostor {
-  background: #fef3c7;
-  border: 1px solid #f59e0b;
-  padding: 0.75rem 1rem;
-  border-radius: 6px;
-  margin-bottom: 1rem;
-  display: flex;
-  gap: 1.5rem;
-  justify-content: space-between;
+  text-align: center;
 }
 
 .canvas-area {
@@ -54,69 +47,31 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-direction: column;
+  width: 100%;
 }
 
-.canvas-area .hint {
+.turn-hint {
   text-align: center;
-  color: #666;
+  color: #7a5530;
   margin-bottom: 0.5rem;
+  font-size: 0.9rem;
 }
 
 .waiting,
 .empty-canvas {
   padding: 4rem;
   text-align: center;
-  color: #999;
-  border: 2px dashed #ddd;
+  color: #7a5530;
+  border: 2px dashed rgba(92, 58, 30, 0.6);
   border-radius: 8px;
-  background: #fafafa;
+  background: rgba(46, 21, 5, 0.4);
   width: 100%;
 }
 
 .spectator-img {
   max-width: 100%;
-  border: 1px solid #ddd;
+  border: 1px solid rgba(92, 58, 30, 0.6);
   border-radius: 4px;
   background: #fff;
-}
-
-.impostor-guess-box {
-  margin-top: 1rem;
-  padding: 0.75rem 1rem;
-  background: #f5f3ff;
-  border: 1px solid #8b5cf6;
-  border-radius: 6px;
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-  flex-wrap: wrap;
-}
-
-.impostor-guess-box label {
-  font-weight: 600;
-  color: #5b21b6;
-}
-
-.impostor-guess-box input {
-  flex: 1;
-  min-width: 200px;
-  padding: 0.4rem 0.6rem;
-  border: 1px solid #c4b5fd;
-  border-radius: 4px;
-  font-size: 0.95rem;
-}
-
-.impostor-guess-box button {
-  padding: 0.4rem 1rem;
-  background: #8b5cf6;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.impostor-guess-box button:disabled {
-  background: #c4b5fd;
-  cursor: not-allowed;
 }

--- a/frontend/src/app/features/game/components/drawing-phase-view/drawing-phase-view.css
+++ b/frontend/src/app/features/game/components/drawing-phase-view/drawing-phase-view.css
@@ -13,7 +13,8 @@
 .phase-header h2 {
   margin: 0;
   font-family: 'Cinzel', serif;
-  font-size: 1.15rem;
+  font-size: clamp(1.3rem, 3.5vw, 1.7rem);
+  font-weight: 700;
   color: #c9a86c;
   letter-spacing: 0.04em;
 }

--- a/frontend/src/app/features/game/components/drawing-phase-view/drawing-phase-view.html
+++ b/frontend/src/app/features/game/components/drawing-phase-view/drawing-phase-view.html
@@ -10,13 +10,6 @@
     </div>
   }
 
-  @if (isImpostor()) {
-    <div class="hint-banner impostor">
-      <span data-testid="impostor-hint">Pista: <strong>{{ state().hint }}</strong></span>
-      <span data-testid="impostor-lives">Vidas: <strong>{{ state().impostorLives }}</strong></span>
-    </div>
-  }
-
   <main class="canvas-area">
     @if (state().currentDrawerId === null) {
       <div class="waiting" data-testid="waiting-for-turn">
@@ -24,12 +17,12 @@
       </div>
     } @else if (canDraw()) {
       <div data-testid="active-canvas">
-        <p class="hint">Es tu turno. Dibuja la palabra.</p>
+        <p class="turn-hint">Es tu turno. Dibuja la palabra.</p>
         <app-canvas [isActive]="true" [showWord]="state().secretWord ?? ''" />
       </div>
     } @else {
       <div class="spectator" data-testid="spectator-view">
-        <p class="hint">{{ state().currentDrawerId }} está dibujando…</p>
+        <p class="turn-hint">{{ state().currentDrawerId }} está dibujando…</p>
         @if (drawerSnapshot()) {
           <img [src]="drawerSnapshot()" alt="Dibujo en directo" class="spectator-img" />
         } @else {
@@ -38,23 +31,4 @@
       </div>
     }
   </main>
-
-  @if (isImpostor()) {
-    <!-- PENDING — P6 entregará 2I.8 (UI flotante). Este bloque inline es un fallback. -->
-    <aside class="impostor-guess-box" data-testid="impostor-guess-box">
-      <label for="guess-input">Intento de adivinación:</label>
-      <input
-        id="guess-input"
-        data-testid="impostor-guess-input"
-        type="text"
-        placeholder="¿cuál es la palabra?"
-        [value]="guessText()"
-        (input)="onGuessInput($event)"
-        (keydown.enter)="submitGuess()"
-      />
-      <button data-testid="impostor-guess-submit" (click)="submitGuess()" [disabled]="!guessText().trim()">
-        Enviar
-      </button>
-    </aside>
-  }
 </div>

--- a/frontend/src/app/features/game/components/gallery-view/gallery-view.css
+++ b/frontend/src/app/features/game/components/gallery-view/gallery-view.css
@@ -1,2 +1,81 @@
-.phase-placeholder { padding: 1rem; border: 2px dashed #999; border-radius: 8px; background: #fafafa; }
-.phase-placeholder pre { font-size: 0.75rem; background: #eee; padding: 0.5rem; border-radius: 4px; overflow-x: auto; }
+.gallery-view {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.phase-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.phase-header h2 {
+  margin: 0;
+  font-family: 'Cinzel', serif;
+  font-size: 1.15rem;
+  color: #c9a86c;
+  letter-spacing: 0.04em;
+}
+
+.timer {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  background: rgba(201, 168, 108, 0.12);
+  border: 1px solid #c9a86c;
+  color: #c9a86c;
+  padding: 0.25rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-family: 'Nunito', sans-serif;
+}
+
+.instructions {
+  color: #7a5530;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.gallery-card {
+  background: rgba(46, 21, 5, 0.6);
+  border: 1px solid rgba(92, 58, 30, 0.7);
+  border-radius: 8px;
+  padding: 0.65rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  text-align: center;
+}
+
+.player-label {
+  font-weight: 600;
+  color: #c9a86c;
+  font-size: 0.85rem;
+  letter-spacing: 0.03em;
+}
+
+.gallery-thumb {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: contain;
+  background: #fff;
+  border-radius: 4px;
+}
+
+.no-drawing {
+  aspect-ratio: 4 / 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(46, 21, 5, 0.4);
+  border: 1px dashed rgba(92, 58, 30, 0.5);
+  border-radius: 4px;
+  color: #7a5530;
+  font-size: 0.875rem;
+}

--- a/frontend/src/app/features/game/components/gallery-view/gallery-view.css
+++ b/frontend/src/app/features/game/components/gallery-view/gallery-view.css
@@ -13,7 +13,8 @@
 .phase-header h2 {
   margin: 0;
   font-family: 'Cinzel', serif;
-  font-size: 1.15rem;
+  font-size: clamp(1.3rem, 3.5vw, 1.7rem);
+  font-weight: 700;
   color: #c9a86c;
   letter-spacing: 0.04em;
 }

--- a/frontend/src/app/features/game/components/game-over-view/game-over-view.css
+++ b/frontend/src/app/features/game/components/game-over-view/game-over-view.css
@@ -1,41 +1,44 @@
 .game-over-view {
-  background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
-  padding: 1.5rem;
+  max-width: 600px;
+  margin: 2rem auto;
   text-align: center;
+  font-family: 'Nunito', sans-serif;
+  color: #fdf5e6;
 }
 
 .winner-banner {
-  padding: 2rem 1rem;
+  padding: 2rem 1.5rem;
   border-radius: 8px;
   margin-bottom: 1.5rem;
 }
 
 .winner-banner.painters {
-  background: linear-gradient(135deg, #ecfdf5 0%, #d1fae5 100%);
-  border: 2px solid #10b981;
+  background: rgba(82, 183, 136, 0.1);
+  border: 2px solid rgba(82, 183, 136, 0.5);
 }
 
 .winner-banner.impostor {
-  background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
-  border: 2px solid #f59e0b;
+  background: rgba(124, 77, 255, 0.1);
+  border: 2px solid rgba(124, 77, 255, 0.5);
 }
 
 .winner-banner h2 {
   margin: 0 0 0.5rem 0;
-  font-size: 2rem;
+  font-family: 'Cinzel', serif;
+  font-size: 1.8rem;
+  color: #c9a86c;
+  letter-spacing: 0.04em;
 }
 
 .winner-banner .reason {
   margin: 0;
-  color: #555;
-  font-size: 1rem;
+  color: #7a5530;
+  font-size: 0.95rem;
 }
 
 .reveal {
   display: grid;
-  gap: 0.75rem;
+  gap: 0.5rem;
   margin: 0 auto 1.5rem auto;
   max-width: 480px;
   text-align: left;
@@ -44,43 +47,60 @@
 .reveal-row {
   display: flex;
   justify-content: space-between;
-  padding: 0.5rem 0.75rem;
-  background: #f9fafb;
-  border-radius: 4px;
-  border: 1px solid #e5e7eb;
+  align-items: center;
+  padding: 0.55rem 0.9rem;
+  background: rgba(46, 21, 5, 0.55);
+  border-radius: 6px;
+  border: 1px solid rgba(92, 58, 30, 0.5);
   margin: 0;
 }
 
 .reveal-row dt {
   font-weight: 600;
-  color: #555;
+  color: #7a5530;
+  font-size: 0.9rem;
 }
 
 .reveal-row dd {
   margin: 0;
-  color: #111;
+  color: #fdf5e6;
+  font-weight: 600;
+}
+
+.reveal-row dd.elo-positive {
+  color: #52b788;
+  font-weight: 700;
+}
+
+.reveal-row dd.elo-negative {
+  color: #e84545;
+  font-weight: 700;
 }
 
 .play-again {
-  background: #2563eb;
-  color: white;
-  border: none;
-  padding: 0.75rem 2rem;
-  border-radius: 6px;
+  background: transparent;
+  color: #c9a86c;
+  border: 2px solid #5c3a1e;
+  padding: 0.75rem 2.5rem;
+  border-radius: 4px;
+  font-family: 'Nunito', sans-serif;
   font-size: 1rem;
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background 0.2s, transform 0.15s;
+  letter-spacing: 0.03em;
 }
 
 .play-again:hover {
-  background: #1d4ed8;
+  background: rgba(201, 168, 108, 0.1);
+  transform: translateY(-1px);
+}
+
+.play-again:active {
+  transform: translateY(0);
 }
 
 .no-game-over {
   padding: 2rem;
-  color: #999;
+  color: #7a5530;
 }
-
-.reveal-row dd.elo-positive { color: #10b981; font-weight: 700; }
-.reveal-row dd.elo-negative { color: #ef4444; font-weight: 700; }

--- a/frontend/src/app/features/game/components/tie-break-view/tie-break-view.css
+++ b/frontend/src/app/features/game/components/tie-break-view/tie-break-view.css
@@ -13,7 +13,8 @@
 .phase-header h2 {
   margin: 0;
   font-family: 'Cinzel', serif;
-  font-size: 1.15rem;
+  font-size: clamp(1.3rem, 3.5vw, 1.7rem);
+  font-weight: 700;
   color: #e84545;
   letter-spacing: 0.04em;
 }

--- a/frontend/src/app/features/game/components/tie-break-view/tie-break-view.css
+++ b/frontend/src/app/features/game/components/tie-break-view/tie-break-view.css
@@ -1,8 +1,6 @@
 .tie-break-view {
-  background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
-  padding: 1.25rem;
+  max-width: 900px;
+  margin: 0 auto;
 }
 
 .phase-header {
@@ -14,72 +12,78 @@
 
 .phase-header h2 {
   margin: 0;
-  font-size: 1.25rem;
-  color: #333;
+  font-family: 'Cinzel', serif;
+  font-size: 1.15rem;
+  color: #e84545;
+  letter-spacing: 0.04em;
 }
 
 .timer {
   font-variant-numeric: tabular-nums;
-  font-weight: 600;
-  background: #dc2626;
-  color: white;
-  padding: 0.25rem 0.75rem;
+  font-weight: 700;
+  background: rgba(232, 69, 69, 0.12);
+  border: 1px solid #e84545;
+  color: #e84545;
+  padding: 0.25rem 0.85rem;
   border-radius: 999px;
-  font-size: 0.875rem;
+  font-size: 0.9rem;
+  font-family: 'Nunito', sans-serif;
 }
 
 .instructions {
   margin-bottom: 1rem;
+  font-size: 0.95rem;
 }
 
 .impostor-prompt {
-  color: #b91c1c;
-  font-weight: 600;
+  color: #e84545;
+  font-weight: 700;
 }
 
 .waiting-prompt {
-  color: #555;
+  color: #7a5530;
 }
 
 .vote-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   gap: 1rem;
 }
 
-/* Clickable card — impostor only */
+/* ── Clickable card (impostor) ── */
 .vote-card {
-  background: #fff;
-  border: 2px solid #e5e7eb;
+  background: rgba(46, 21, 5, 0.6);
+  border: 2px solid rgba(92, 58, 30, 0.7);
   border-radius: 8px;
   padding: 0.75rem;
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
   text-align: center;
-  font-family: inherit;
+  font-family: 'Nunito', sans-serif;
+  color: #fdf5e6;
 }
 
 .vote-card:hover:not(:disabled) {
-  border-color: #dc2626;
+  border-color: #e84545;
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(220, 38, 38, 0.15);
+  box-shadow: 0 4px 16px rgba(232, 69, 69, 0.2);
 }
 
 .vote-card.voted {
-  border-color: #10b981;
-  background: #ecfdf5;
+  border-color: #52b788;
+  background: rgba(82, 183, 136, 0.1);
 }
 
 .vote-card.previous-vote {
-  border-color: #f59e0b;
-  background: #fffbeb;
+  border-color: #c9a86c;
+  background: rgba(201, 168, 108, 0.08);
 }
 
 .vote-card.disabled {
-  opacity: 0.5;
+  opacity: 0.45;
   cursor: not-allowed;
 }
 
@@ -87,39 +91,42 @@
   cursor: default;
 }
 
-/* Read-only card — non-impostor players */
+/* ── Read-only card (non-impostor) ── */
 .tied-readonly {
-  background: #f9fafb;
-  border: 2px solid #e5e7eb;
+  background: rgba(46, 21, 5, 0.45);
+  border: 2px solid rgba(92, 58, 30, 0.5);
   border-radius: 8px;
   padding: 0.75rem;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
   text-align: center;
+  color: #fdf5e6;
 }
 
 .player-label {
-  font-weight: 600;
-  color: #333;
+  font-weight: 700;
+  color: #c9a86c;
+  font-size: 0.9rem;
 }
 
 .self-marker {
   display: inline-block;
   margin-left: 0.4rem;
   padding: 0.1rem 0.4rem;
-  background: #dbeafe;
-  color: #1d4ed8;
+  background: rgba(201, 168, 108, 0.15);
+  color: #c9a86c;
   border-radius: 999px;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   font-weight: 700;
+  border: 1px solid rgba(201, 168, 108, 0.4);
 }
 
 .vote-count-badge {
   display: inline-block;
-  background: #fef3c7;
-  color: #92400e;
-  border: 1px solid #fcd34d;
+  background: rgba(201, 168, 108, 0.12);
+  color: #c9a86c;
+  border: 1px solid rgba(201, 168, 108, 0.4);
   border-radius: 999px;
   font-size: 0.75rem;
   font-weight: 700;
@@ -131,8 +138,8 @@
   width: 100%;
   aspect-ratio: 4 / 3;
   object-fit: contain;
-  background: #fafafa;
-  border: 1px solid #ddd;
+  background: #fff;
+  border: 1px solid rgba(92, 58, 30, 0.5);
   border-radius: 4px;
 }
 
@@ -141,34 +148,36 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #f9fafb;
-  border: 1px dashed #d1d5db;
+  background: rgba(46, 21, 5, 0.4);
+  border: 1px dashed rgba(92, 58, 30, 0.5);
   border-radius: 4px;
-  color: #999;
+  color: #7a5530;
   font-size: 0.875rem;
 }
 
 .previous-vote-marker {
-  background: #f59e0b;
-  color: white;
+  background: rgba(201, 168, 108, 0.2);
+  border: 1px solid #c9a86c;
+  color: #c9a86c;
   padding: 0.2rem 0.5rem;
   border-radius: 4px;
   font-size: 0.8rem;
-  font-weight: 600;
+  font-weight: 700;
 }
 
 .vote-marker {
-  background: #10b981;
-  color: white;
+  background: rgba(82, 183, 136, 0.2);
+  border: 1px solid #52b788;
+  color: #7de8b0;
   padding: 0.2rem 0.5rem;
   border-radius: 4px;
   font-size: 0.8rem;
-  font-weight: 600;
+  font-weight: 700;
 }
 
 .confirmation {
   margin-top: 1rem;
   text-align: center;
-  color: #10b981;
+  color: #7de8b0;
   font-weight: 600;
 }

--- a/frontend/src/app/features/game/components/vote-result-view/vote-result-view.css
+++ b/frontend/src/app/features/game/components/vote-result-view/vote-result-view.css
@@ -1,2 +1,89 @@
-.phase-placeholder { padding: 1rem; border: 2px dashed #999; border-radius: 8px; background: #fafafa; }
-.phase-placeholder pre { font-size: 0.75rem; background: #eee; padding: 0.5rem; border-radius: 4px; overflow-x: auto; }
+.vote-result-view {
+  max-width: 600px;
+  margin: 2rem auto;
+  text-align: center;
+  color: #fdf5e6;
+  font-family: 'Nunito', sans-serif;
+}
+
+.phase-header h2 {
+  font-family: 'Cinzel', serif;
+  font-size: 1.3rem;
+  color: #c9a86c;
+  letter-spacing: 0.04em;
+  margin: 0 0 1.5rem 0;
+}
+
+.no-elimination {
+  padding: 1.5rem;
+  background: rgba(46, 21, 5, 0.55);
+  border: 1px solid rgba(92, 58, 30, 0.6);
+  border-radius: 8px;
+  color: #f5e6c8;
+  margin-bottom: 1.5rem;
+}
+
+.elimination-result {
+  padding: 1.5rem;
+  background: rgba(46, 21, 5, 0.55);
+  border: 1px solid rgba(92, 58, 30, 0.6);
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+  font-size: 1.05rem;
+}
+
+.elimination-result p {
+  margin: 0 0 0.5rem 0;
+  color: #f5e6c8;
+}
+
+.impostor-reveal {
+  font-weight: 700;
+  font-size: 1.1rem;
+  margin-top: 0.5rem !important;
+}
+
+.impostor-reveal.was-impostor {
+  color: #52b788;
+}
+
+.impostor-reveal.not-impostor {
+  color: #e84545;
+}
+
+.top-voted-section {
+  background: rgba(46, 21, 5, 0.45);
+  border: 1px solid rgba(92, 58, 30, 0.5);
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  text-align: left;
+}
+
+.top-voted-section h3 {
+  font-family: 'Cinzel', serif;
+  color: #c9a86c;
+  font-size: 0.9rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin: 0 0 0.75rem 0;
+}
+
+.top-voted-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.top-voted-list li {
+  color: #f5e6c8;
+  font-size: 0.95rem;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid rgba(92, 58, 30, 0.3);
+}
+
+.top-voted-list li:last-child {
+  border-bottom: none;
+}

--- a/frontend/src/app/features/game/components/voting-view/voting-view.css
+++ b/frontend/src/app/features/game/components/voting-view/voting-view.css
@@ -1,8 +1,6 @@
 .voting-view {
-  background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
-  padding: 1.25rem;
+  max-width: 900px;
+  margin: 0 auto;
 }
 
 .phase-header {
@@ -14,58 +12,76 @@
 
 .phase-header h2 {
   margin: 0;
-  font-size: 1.25rem;
-  color: #333;
+  font-family: 'Cinzel', serif;
+  font-size: 1.15rem;
+  color: #c9a86c;
+  letter-spacing: 0.04em;
 }
 
 .timer {
   font-variant-numeric: tabular-nums;
-  font-weight: 600;
-  background: #2563eb;
-  color: white;
-  padding: 0.25rem 0.75rem;
+  font-weight: 700;
+  background: rgba(201, 168, 108, 0.12);
+  border: 1px solid #c9a86c;
+  color: #c9a86c;
+  padding: 0.25rem 0.85rem;
   border-radius: 999px;
-  font-size: 0.875rem;
+  font-size: 0.9rem;
+  font-family: 'Nunito', sans-serif;
 }
 
 .instructions {
-  color: #555;
+  color: #f5e6c8;
   margin-bottom: 1rem;
+  font-size: 0.95rem;
+}
+
+.eliminated-notice {
+  margin-bottom: 1rem;
+  padding: 0.6rem 1rem;
+  background: rgba(46, 21, 5, 0.6);
+  border: 1px solid rgba(92, 58, 30, 0.7);
+  border-radius: 6px;
+  color: #c9a86c;
+  font-weight: 600;
+  text-align: center;
 }
 
 .vote-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   gap: 1rem;
 }
 
+/* ── Clickable vote card ── */
 .vote-card {
-  background: #fff;
-  border: 2px solid #e5e7eb;
+  background: rgba(46, 21, 5, 0.6);
+  border: 2px solid rgba(92, 58, 30, 0.7);
   border-radius: 8px;
   padding: 0.75rem;
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
   text-align: center;
-  font-family: inherit;
+  font-family: 'Nunito', sans-serif;
+  color: #fdf5e6;
 }
 
 .vote-card:hover:not(:disabled) {
-  border-color: #2563eb;
+  border-color: #c9a86c;
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(37, 99, 235, 0.15);
+  box-shadow: 0 4px 16px rgba(201, 168, 108, 0.2);
 }
 
 .vote-card.voted {
-  border-color: #10b981;
-  background: #ecfdf5;
+  border-color: #52b788;
+  background: rgba(82, 183, 136, 0.1);
 }
 
 .vote-card.disabled {
-  opacity: 0.5;
+  opacity: 0.45;
   cursor: not-allowed;
 }
 
@@ -73,28 +89,37 @@
   cursor: default;
 }
 
+/* ── Spectator (eliminated player) card ── */
+.vote-card.spectator {
+  cursor: default;
+  opacity: 0.65;
+  border-style: dashed;
+}
+
 .player-label {
-  font-weight: 600;
-  color: #333;
+  font-weight: 700;
+  color: #c9a86c;
+  font-size: 0.9rem;
 }
 
 .self-marker {
   display: inline-block;
   margin-left: 0.4rem;
   padding: 0.1rem 0.4rem;
-  background: #dbeafe;
-  color: #1d4ed8;
+  background: rgba(201, 168, 108, 0.15);
+  color: #c9a86c;
   border-radius: 999px;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   font-weight: 700;
+  border: 1px solid rgba(201, 168, 108, 0.4);
 }
 
 .vote-thumb {
   width: 100%;
   aspect-ratio: 4 / 3;
   object-fit: contain;
-  background: #fafafa;
-  border: 1px solid #ddd;
+  background: #fff;
+  border: 1px solid rgba(92, 58, 30, 0.5);
   border-radius: 4px;
 }
 
@@ -103,42 +128,26 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #f9fafb;
-  border: 1px dashed #d1d5db;
+  background: rgba(46, 21, 5, 0.4);
+  border: 1px dashed rgba(92, 58, 30, 0.5);
   border-radius: 4px;
-  color: #999;
+  color: #7a5530;
   font-size: 0.875rem;
 }
 
 .vote-marker {
-  background: #10b981;
-  color: white;
+  background: rgba(82, 183, 136, 0.25);
+  border: 1px solid #52b788;
+  color: #7de8b0;
   padding: 0.2rem 0.5rem;
   border-radius: 4px;
   font-size: 0.8rem;
-  font-weight: 600;
+  font-weight: 700;
 }
 
 .confirmation {
   margin-top: 1rem;
   text-align: center;
-  color: #10b981;
+  color: #7de8b0;
   font-weight: 600;
-}
-
-.eliminated-notice {
-  margin-bottom: 1rem;
-  padding: 0.6rem 1rem;
-  background: #fef3c7;
-  border: 1px solid #fcd34d;
-  border-radius: 6px;
-  color: #92400e;
-  font-weight: 600;
-  text-align: center;
-}
-
-.vote-card.spectator {
-  cursor: default;
-  opacity: 0.75;
-  border-style: dashed;
 }

--- a/frontend/src/app/features/game/components/voting-view/voting-view.css
+++ b/frontend/src/app/features/game/components/voting-view/voting-view.css
@@ -13,7 +13,8 @@
 .phase-header h2 {
   margin: 0;
   font-family: 'Cinzel', serif;
-  font-size: 1.15rem;
+  font-size: clamp(1.3rem, 3.5vw, 1.7rem);
+  font-weight: 700;
   color: #c9a86c;
   letter-spacing: 0.04em;
 }

--- a/frontend/src/app/features/game/containers/game/game.css
+++ b/frontend/src/app/features/game/containers/game/game.css
@@ -1,36 +1,53 @@
 :host {
   display: block;
-  padding: 1.5rem;
-  max-width: 1200px;
-  margin: 0 auto;
 }
 
-.not-auth, .connecting {
+.game-page {
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+  padding: 1.5rem;
+  font-family: 'Nunito', sans-serif;
+  color: #fdf5e6;
+}
+
+.not-auth,
+.connecting {
   padding: 2rem;
   text-align: center;
-  background: #fff8e1;
-  border: 2px dashed #f9a825;
+  color: #c9a86c;
+  border: 2px dashed #5c3a1e;
   border-radius: 8px;
+  background: rgba(46, 21, 5, 0.6);
+  max-width: 480px;
+  margin: 4rem auto;
 }
 
 .eliminated-banner {
-  background: #fef3c7;
-  border: 1px solid #fcd34d;
+  background: rgba(46, 21, 5, 0.75);
+  border: 1px solid #5c3a1e;
   border-radius: 6px;
-  color: #92400e;
+  color: #c9a86c;
   font-weight: 600;
   padding: 0.6rem 1rem;
   margin-bottom: 1rem;
   text-align: center;
+  max-width: 900px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .dev-banner {
-  background: #2563eb;
-  color: white;
+  background: rgba(37, 99, 235, 0.25);
+  border: 1px solid rgba(37, 99, 235, 0.5);
+  color: #93c5fd;
   padding: 0.5rem 1rem;
   border-radius: 6px;
   margin-bottom: 1rem;
   font-size: 0.875rem;
+  max-width: 900px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .dev-link {
@@ -39,6 +56,7 @@
   text-decoration: underline;
   cursor: pointer;
 }
+
 .dev-link:hover {
   color: #fff;
 }

--- a/frontend/src/app/features/game/containers/game/game.html
+++ b/frontend/src/app/features/game/containers/game/game.html
@@ -1,78 +1,77 @@
-@if (notAuthenticated) {
-  <div class="not-auth" data-testid="not-auth">
-    <h2>No autenticado</h2>
-    <p>Necesitas iniciar sesión para entrar a una sala de juego.</p>
-    <p><em>(O añade <code>?dev=true</code> a la URL para entrar en modo demo.)</em></p>
-  </div>
-} @else {
-  @if (devMode) {
-    <div class="dev-banner">
-      🛠️ MODO DEV
-      @if (gameState.isImpostor()) {
-        — Rol: <strong>IMPOSTOR</strong> · Pista: <strong>{{ gameState.hint() }}</strong>
-      } @else {
-        — Rol: <strong>PINTOR</strong>
-        · <a class="dev-link" href="?dev=true&role=impostor">Cambiar a impostor →</a>
+<div class="game-page">
+  <app-game-background />
+
+  @if (notAuthenticated) {
+    <div class="not-auth" data-testid="not-auth">
+      <h2>No autenticado</h2>
+      <p>Necesitas iniciar sesión para entrar a una sala de juego.</p>
+      <p><em>(O añade <code>?dev=true</code> a la URL para entrar en modo demo.)</em></p>
+    </div>
+  } @else {
+    @if (devMode) {
+      <div class="dev-banner">
+        🛠️ MODO DEV
+        @if (gameState.isImpostor()) {
+          — Rol: <strong>IMPOSTOR</strong> · Pista: <strong>{{ gameState.hint() }}</strong>
+        } @else {
+          — Rol: <strong>PINTOR</strong>
+          · <a class="dev-link" href="?dev=true&role=impostor">Cambiar a impostor →</a>
+        }
+      </div>
+    }
+
+    @if (isLocalPlayerEliminated() && gameState.phase() !== 'OVER') {
+      <div class="eliminated-banner" data-testid="eliminated-banner">
+        👻 Has sido eliminado. Puedes ver cómo continúa la partida, pero ya no puedes participar.
+      </div>
+    }
+
+    @switch (gameState.phase()) {
+      @case ('CONNECTING') {
+        <div class="connecting"><h2>Conectando…</h2></div>
       }
-    </div>
-  }
+      @case ('DRAWING') {
+        <app-drawing-phase-view
+          [state]="gameState.state()"
+          [myPlayerId]="myPlayerId"
+          (drawCommand)="sendDraw($event)"
+          (guessSubmitted)="sendGuess($event)"
+        />
+      }
+      @case ('GALLERY') {
+        <app-gallery-view [state]="gameState.state()" />
+      }
+      @case ('VOTING') {
+        <app-voting-view
+          [state]="gameState.state()"
+          [myPlayerId]="myPlayerId"
+          (voteCast)="sendVote($event)"
+        />
+      }
+      @case ('TIE_BREAK') {
+        <app-tie-break-view
+          [state]="gameState.state()"
+          [myPlayerId]="myPlayerId"
+          [myPreviousVote]="myVotedPlayerId"
+          (voteMoved)="sendVoteMove($event)"
+        />
+      }
+      @case ('RESULT') {
+        <app-vote-result-view [state]="gameState.state()" />
+      }
+      @case ('OVER') {
+        <app-game-over-view
+          [state]="gameState.state()"
+          (playAgain)="onPlayAgain()"
+        />
+      }
+    }
 
-  @if (isLocalPlayerEliminated() && gameState.phase() !== 'OVER') {
-    <div class="eliminated-banner" data-testid="eliminated-banner">
-      👻 Has sido eliminado. Puedes ver cómo continúa la partida, pero ya no puedes participar.
-    </div>
+    <app-impostor-overlay
+      [visible]="isOverlayVisible()"
+      [hint]="gameState.hint()"
+      [lives]="gameState.impostorLives()"
+      (guessSubmitted)="sendGuess($event)"
+    />
   }
-
-  @switch (gameState.phase()) {
-    @case ('CONNECTING') {
-      <div class="connecting"><h2>Conectando…</h2></div>
-    }
-    @case ('DRAWING') {
-      <app-drawing-phase-view
-        [state]="gameState.state()"
-        [myPlayerId]="myPlayerId"
-        (drawCommand)="sendDraw($event)"
-        (guessSubmitted)="sendGuess($event)"
-      />
-    }
-    @case ('GALLERY') {
-      <app-gallery-view [state]="gameState.state()" />
-    }
-    @case ('VOTING') {
-      <app-voting-view
-        [state]="gameState.state()"
-        [myPlayerId]="myPlayerId"
-        (voteCast)="sendVote($event)"
-      />
-    }
-    @case ('TIE_BREAK') {
-      <app-tie-break-view
-        [state]="gameState.state()"
-        [myPlayerId]="myPlayerId"
-        [myPreviousVote]="myVotedPlayerId"
-        (voteMoved)="sendVoteMove($event)"
-      />
-    }
-    @case ('RESULT') {
-      <app-vote-result-view [state]="gameState.state()" />
-    }
-    @case ('OVER') {
-      <app-game-over-view
-        [state]="gameState.state()"
-        (playAgain)="onPlayAgain()"
-      />
-    }
-  }
-
-  <!--
-    2I.8 — UI flotante del impostor.
-    La visibilidad se calcula aquí en el padre con signals directas del GameStateService,
-    evitando problemas de hydration SSR. Los valores se pasan como @Input al componente.
-  -->
-  <app-impostor-overlay
-    [visible]="isOverlayVisible()"
-    [hint]="gameState.hint()"
-    [lives]="gameState.impostorLives()"
-    (guessSubmitted)="sendGuess($event)"
-  />
-}
+</div>

--- a/frontend/src/app/features/game/containers/game/game.ts
+++ b/frontend/src/app/features/game/containers/game/game.ts
@@ -14,6 +14,7 @@ import { TieBreakView } from '../../components/tie-break-view/tie-break-view';
 import { VoteResultView } from '../../components/vote-result-view/vote-result-view';
 import { GameOverView } from '../../components/game-over-view/game-over-view';
 import { ImpostorOverlay } from '../../components/impostor-overlay/impostor-overlay';
+import { GameBackgroundComponent } from '../../../../shared/components/game-background/game-background.component';
 import { DrawBroadcast, DrawCommand, GameEvent } from '../../models/game-event';
 import { PrivateMessage, RoleAssignment } from '../../models/role-assignment';
 import { AudioService } from '../../../../core/services/audio.service';
@@ -41,6 +42,7 @@ import { AudioService } from '../../../../core/services/audio.service';
     VoteResultView,
     GameOverView,
     ImpostorOverlay,
+    GameBackgroundComponent,
   ],
   templateUrl: './game.html',
   styleUrl: './game.css',


### PR DESCRIPTION
### Resumen

Las vistas de gameplay (`DrawingPhaseView`, `GalleryView`, `VotingView`, `TieBreakView`, `VoteResultView`, `GameOverView`) tenían un sistema visual completamente distinto al del resto de la aplicación: fondos blancos, texto gris, botones azules y tipografía genérica. Esta PR aplica el sistema de diseño ya establecido en home, lobby y matchmaking a todas las vistas de juego, y elimina dos elementos de UI duplicados del impostor que coexistían con el panel flotante oficial (`ImpostorOverlay`).

---

### Cambios

| Fichero | Qué se ha cambiado |
|---|---|
| `game.ts` | Importado `GameBackgroundComponent` |
| `game.html` | Envuelto el contenido en `.game-page`; añadido `<app-game-background />` para el fondo oscuro compartido |
| `game.css` | Contenedor a pantalla completa con fondo `#1a0e05`; banners de eliminado y modo dev adaptados al tema oscuro |
| `drawing-phase-view.html` | **Eliminados** el banner amarillo `hint-banner.impostor` (`#fef3c7`) y el `aside.impostor-guess-box` inline — ambos duplicaban funcionalidad ya cubierta por `ImpostorOverlay` |
| `drawing-phase-view.css` | Fondo blanco eliminado; temporizador con borde dorado; banner de palabra del pintor en verde tenue; estados de espera con fondo oscuro y borde discontinuo |
| `gallery-view.css` | Tema oscuro completo desde cero — tarjetas oscuras con borde marrón, etiquetas de jugador en dorado, miniaturas con fondo blanco preservado |
| `voting-view.css` | Tarjetas de voto oscuras con borde marrón; hover en dorado; estado votado en verde tenue; eliminado todo rastro de azul y blanco |
| `tie-break-view.css` | Color rojo/urgencia para título y temporizador (señaliza peligro de eliminación); tarjetas oscuras; estado voto-anterior en dorado; voto confirmado en verde |
| `vote-result-view.css` | Tema oscuro completo desde cero — paneles de resultado oscuros, colores verde/rojo para revelar si era el impostor |
| `game-over-view.css` | Fondo blanco eliminado; victoria pintores = tinte verde, victoria impostor = tinte morado; filas de estadísticas oscuras; botón "Jugar otra vez" estilo fantasma en dorado |
| `canvas.html` | Eliminado el bloque `word-display` ("Palabra: …") de la barra de herramientas — la palabra ya se muestra en el banner de la vista de dibujo |
| Todos los CSS de fase | Título de fase (`h2`) ampliado a `clamp(1.3rem, 3.5vw, 1.7rem)` con `font-weight: 700` para que tenga la presencia visual adecuada |

---

### Lo que NO ha cambiado

- Toda la lógica de juego y los bindings Angular son idénticos.
- El canvas de dibujo, la paleta de colores y los controles del pincel no se han tocado.
- El `ImpostorOverlay` (panel morado flotante) se mantiene intacto — era el único elemento correcto desde el principio.
- No se han añadido ni eliminado rutas, servicios ni componentes.