### PR TITLE
Fix: El sistema que carga y selecciona las palabras (wordGroup) no cargaba las palabras en start up y las seleccionaba mal

### DIFF
--- a/backend/src/main/java/com/impaintor/feature/game/service/GameService.java
+++ b/backend/src/main/java/com/impaintor/feature/game/service/GameService.java
@@ -79,14 +79,9 @@ public class GameService implements GameInputHandler {
         }
 
         WordGroup wordGroup = resolveWordGroup(room);
-        List<String> candidateWords = new ArrayList<>();
-        candidateWords.add(wordGroup.getWord1());
-        candidateWords.add(wordGroup.getWord2());
-        candidateWords.add(wordGroup.getWord3());
-        Collections.shuffle(candidateWords);
-
-        String secretWord = candidateWords.get(0);
-        String hintWord = candidateWords.get(1);
+        // word1 is always the drawable word shown to painters; hint is randomly chosen from word2 or word3
+        String secretWord = wordGroup.getWord1();
+        String hintWord = Math.random() < 0.5 ? wordGroup.getWord2() : wordGroup.getWord3();
 
         List<User> shuffledPlayers = new ArrayList<>(players);
         Collections.shuffle(shuffledPlayers);

--- a/backend/src/main/java/com/impaintor/feature/wordgroup/WordGroupSeeder.java
+++ b/backend/src/main/java/com/impaintor/feature/wordgroup/WordGroupSeeder.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -27,11 +28,11 @@ public class WordGroupSeeder implements CommandLineRunner {
     }
 
     @Override
+    @Transactional
     public void run(String... args) throws Exception {
-        long existing = repository.countByLanguage("es");
-        if (existing > 0) {
-            log.info("WordGroup seed skipped: {} Spanish groups already in database.", existing);
-            return;
+        long deleted = repository.deleteBySource("pipeline");
+        if (deleted > 0) {
+            log.info("Removed {} stale pipeline word groups.", deleted);
         }
 
         log.info("Seeding word groups from {} ...", CSV_PATH);

--- a/backend/src/main/java/com/impaintor/feature/wordgroup/WordGroupSeeder.java
+++ b/backend/src/main/java/com/impaintor/feature/wordgroup/WordGroupSeeder.java
@@ -30,6 +30,7 @@ public class WordGroupSeeder implements CommandLineRunner {
     @Override
     @Transactional
     public void run(String... args) throws Exception {
+        repository.clearRoomWordGroupReferences();
         long deleted = repository.deleteBySource("pipeline");
         if (deleted > 0) {
             log.info("Removed {} stale pipeline word groups.", deleted);

--- a/backend/src/main/java/com/impaintor/feature/wordgroup/repositories/WordGroupRepository.java
+++ b/backend/src/main/java/com/impaintor/feature/wordgroup/repositories/WordGroupRepository.java
@@ -19,4 +19,6 @@ public interface WordGroupRepository extends JpaRepository<WordGroup, Long> {
     Optional<WordGroup> findRandom();
 
     long countByLanguage(String language);
+
+    long deleteBySource(String source);
 }

--- a/backend/src/main/java/com/impaintor/feature/wordgroup/repositories/WordGroupRepository.java
+++ b/backend/src/main/java/com/impaintor/feature/wordgroup/repositories/WordGroupRepository.java
@@ -3,6 +3,7 @@ package com.impaintor.feature.wordgroup.repositories;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -21,4 +22,8 @@ public interface WordGroupRepository extends JpaRepository<WordGroup, Long> {
     long countByLanguage(String language);
 
     long deleteBySource(String source);
+
+    @Modifying
+    @Query(value = "UPDATE rooms SET word_group_id = NULL", nativeQuery = true)
+    void clearRoomWordGroupReferences();
 }


### PR DESCRIPTION
Ahora se cargas las palabras del csv cuando se inicia el backend.

Las palabras están estructuradas de la siguiente manera, en cada línea tenemos word1, word2 y word3, word1 de cada línea es la palabra dibujable, word2 y word3 son las pistas asociadas a esa palabra. 

Cuando se inicia una sala y se obtiene el wordGroup solo word1 se selecciona para dibujar, y se selecciona aleatoriamente entre word 2 y word 3 la pista. 