### PR TITLE
feat: logout

### DIFF
--- a/frontend/src/app/features/auth/profile/profile.component.css
+++ b/frontend/src/app/features/auth/profile/profile.component.css
@@ -54,6 +54,12 @@
   font-size: 0.95rem;
 }
 
+.header-actions {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
 .back-btn {
   border: 1px solid #9d6a35;
   background: linear-gradient(180deg, #40240d 0%, #291507 100%);
@@ -63,6 +69,29 @@
   cursor: pointer;
   white-space: nowrap;
   box-shadow: inset 0 1px 0 rgba(255, 228, 176, 0.1);
+  transition: transform 0.15s ease, filter 0.15s ease;
+}
+
+.back-btn:hover {
+  filter: brightness(1.1);
+  transform: translateY(-1px);
+}
+
+.logout-btn {
+  border: 1px solid #c0392b;
+  background: linear-gradient(180deg, #7b241c 0%, #511c16 100%);
+  color: #f5e3c0;
+  border-radius: 999px;
+  padding: 0.55rem 1rem;
+  cursor: pointer;
+  white-space: nowrap;
+  box-shadow: inset 0 1px 0 rgba(255, 200, 200, 0.15);
+  transition: transform 0.15s ease, filter 0.15s ease;
+}
+
+.logout-btn:hover {
+  filter: brightness(1.1);
+  transform: translateY(-1px);
 }
 
 .profile-summary {

--- a/frontend/src/app/features/auth/profile/profile.component.html
+++ b/frontend/src/app/features/auth/profile/profile.component.html
@@ -1,6 +1,9 @@
 <div class="profile-page" role="main" aria-label="Perfil de usuario">
   <header class="profile-header">
-    <button type="button" class="back-btn" (click)="goBackToMainMenu()">Volver al menú</button>
+    <div class="header-actions">
+      <button type="button" class="back-btn" (click)="goBackToMainMenu()">Volver al menú</button>
+      <button type="button" class="logout-btn" (click)="logout()">Cerrar sesión</button>
+    </div>
     <div class="header-copy">
       <p class="eyebrow">Perfil</p>
       <h1>Tu espacio personal</h1>

--- a/frontend/src/app/features/auth/profile/profile.component.ts
+++ b/frontend/src/app/features/auth/profile/profile.component.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
+import { AuthService } from '../../../core/services/auth.service';
 
 interface ProfileDraft {
   avatarPreview: string;
@@ -23,6 +24,7 @@ interface ProfileDraft {
 })
 export class ProfileComponent {
   private readonly router = inject(Router);
+  private readonly authService = inject(AuthService);
 
   readonly profileDraft = signal<ProfileDraft>({
     avatarPreview: '',
@@ -45,6 +47,11 @@ export class ProfileComponent {
 
   goBackToMainMenu(): void {
     this.router.navigate(['/main_menu']);
+  }
+
+  logout(): void {
+    this.authService.logout();
+    this.router.navigate(['/']);
   }
 
   onAvatarSelected(event: Event): void {


### PR DESCRIPTION
This pull request updates the user profile page to add a "Cerrar sesión" (Logout) button alongside the existing "Volver al menú" (Back to menu) button. It introduces the logout functionality, improves the layout of header actions, and adds visual feedback on button hover. The most important changes are grouped below.

**New Feature: Logout Functionality**
* Added a "Cerrar sesión" (Logout) button to the profile page header, enabling users to log out directly from their profile.
* Implemented the `logout()` method in `ProfileComponent`, which calls `AuthService.logout()` and navigates the user to the home page.
* Injected `AuthService` into `ProfileComponent` to support the logout operation. [[1]](diffhunk://#diff-f87c5bdafb5b7c46b689146a5cf16375b852fb99fe3c4855d95a7cbe75f55494R5) [[2]](diffhunk://#diff-f87c5bdafb5b7c46b689146a5cf16375b852fb99fe3c4855d95a7cbe75f55494R27)

**UI/UX Improvements**
* Grouped header action buttons ("Back" and "Logout") in a flex container for better layout and responsiveness (`.header-actions`).
* Added new styles for `.logout-btn`, including custom colors, padding, and hover effects. Also improved `.back-btn` with transition and hover feedback for a more interactive user experience.