### PR TITLE
Fix: Errores y problemas generales relacionados con el gameplay / game flow

### DIFF
--- a/backend/src/main/java/com/impaintor/feature/game/service/GameService.java
+++ b/backend/src/main/java/com/impaintor/feature/game/service/GameService.java
@@ -87,6 +87,10 @@ public class GameService implements GameInputHandler {
         Collections.shuffle(shuffledPlayers);
         User impostor = shuffledPlayers.get(0);
 
+        // Shuffle again independently so the impostor's position in the drawing
+        // order is not correlated with their selection (previously always drew first).
+        Collections.shuffle(shuffledPlayers);
+
         List<Long> drawingOrder = new ArrayList<>();
         for (User player : shuffledPlayers) {
             drawingOrder.add(player.getId());
@@ -106,20 +110,19 @@ public class GameService implements GameInputHandler {
 
         activeGames.put(roomCode, gameState);
 
-        realtimePublisher.publishGameEvent(roomCode, new GameEvent.GameStart(drawingOrder, 1));
-
         room.setWordGroup(wordGroup);
         room.setSecretWord(secretWord);
         room.setHintWord(hintWord);
         room.setGameState(Room.GameState.PLAYING);
         roomRepository.save(room);
 
-        // Delay role assignments and first turn so all clients have time to navigate
-        // from the lobby to /game and re-subscribe before TURN_START arrives.
-        // Without this delay, the lobby's still-active subscription consumes TURN_START
-        // and GameComponent never sees it, causing the first drawer to be skipped.
+        // Delay GAME_START, role assignments and first turn so all clients have time
+        // to navigate from the lobby to /game and subscribe before any events arrive.
+        // GAME_START is intentionally inside the delay — if sent immediately it races
+        // the Angular route transition and clients miss it, leaving round stuck at 0.
         final List<User> playerSnapshot = List.copyOf(players);
         ScheduledFuture<?> f = scheduler.schedule(() -> {
+            realtimePublisher.publishGameEvent(roomCode, new GameEvent.GameStart(drawingOrder, 1));
             sendRoleAssignments(playerSnapshot, gameState);
             startNextTurn(roomCode);
         }, 3, TimeUnit.SECONDS);
@@ -431,6 +434,10 @@ public class GameService implements GameInputHandler {
         }
     }
 
+    // Phantom voter ID used to record the impostor's extra tie-break vote without
+    // overwriting their original vote, which stays in place unchanged.
+    private static final Long EXTRA_VOTE_ID = -1L;
+
     @Override
     public void onVoteMove(String roomCode, Long impostorId, Long targetPlayerId) {
         GameState gs = activeGames.get(roomCode);
@@ -442,7 +449,9 @@ public class GameService implements GameInputHandler {
             ScheduledFuture<?> scheduled = scheduledTasks.remove(roomCode);
             if (scheduled != null) scheduled.cancel(false);
 
-            gs.recordVote(impostorId, targetPlayerId);
+            // Extra vote: keep the impostor's original vote in place, add one fresh
+            // vote under the phantom key so any tie configuration is always breakable.
+            gs.recordVote(EXTRA_VOTE_ID, targetPlayerId);
             applyVoteResolution(roomCode, gs);
         }
     }

--- a/frontend/src/app/core/services/websocket.service.ts
+++ b/frontend/src/app/core/services/websocket.service.ts
@@ -94,11 +94,19 @@ export class WebSocketService {
   /** Desconecta limpiamente. No-op si no está conectado. */
   disconnect(): void {
     if (!this.client) return;
-    if (this.client.active) {
-      this.client.deactivate();
-    }
-    this._status$.next('DISCONNECTED');
+    const old = this.client;
+    // Null out first so a subsequent connect() can create a fresh client immediately,
+    // without waiting for the async deactivate() to complete.
+    this.client = null;
     this.pendingSubs = [];
+    this._status$.next('DISCONNECTED');
+    if (old.active) {
+      // Neuter callbacks so the dying connection doesn't overwrite the new client's state.
+      old.onConnect = () => {};
+      old.onWebSocketClose = () => {};
+      old.onStompError = () => {};
+      old.deactivate();
+    }
   }
 
   /**

--- a/frontend/src/app/features/game/components/tie-break-view/tie-break-view.html
+++ b/frontend/src/app/features/game/components/tie-break-view/tie-break-view.html
@@ -13,7 +13,7 @@
 
   @if (isImpostor()) {
     <p class="instructions impostor-prompt" data-testid="impostor-prompt">
-      Mueve tu voto para romper el empate. Si no actúas, serás expulsado.
+      Tienes un voto extra. Úsalo para romper el empate. Si no actúas, serás expulsado.
     </p>
 
     <div class="vote-grid">
@@ -21,7 +21,6 @@
         <button
           class="vote-card"
           [class.voted]="myMove() === entry.id"
-          [class.previous-vote]="myPreviousVote() === entry.id && myMove() === null"
           [class.disabled]="myMove() !== null && myMove() !== entry.id"
           [disabled]="myMove() !== null"
           [attr.data-testid]="'tied-card-' + entry.id"
@@ -42,18 +41,15 @@
             <div class="no-drawing">(sin dibujo)</div>
           }
 
-          @if (myPreviousVote() === entry.id && myMove() === null) {
-            <div class="previous-vote-marker">← Tu voto anterior</div>
-          }
           @if (myMove() === entry.id) {
-            <div class="vote-marker">✓ Tu nuevo voto</div>
+            <div class="vote-marker">✓ Voto extra</div>
           }
         </button>
       }
     </div>
 
     @if (myMove() !== null) {
-      <p class="confirmation">Voto movido. Esperando resultado…</p>
+      <p class="confirmation">Voto extra enviado. Esperando resultado…</p>
     }
   } @else {
     <p class="instructions waiting-prompt" data-testid="waiting-prompt">

--- a/frontend/src/app/features/game/components/tie-break-view/tie-break-view.ts
+++ b/frontend/src/app/features/game/components/tie-break-view/tie-break-view.ts
@@ -6,8 +6,10 @@ import { SpectatorCanvasService } from '../../services/spectator-canvas';
 /**
  * 2I.5 — Vista de desempate.
  *
- * Muestra los jugadores empatados con sus dibujos. El impostor puede mover
- * su voto a uno de ellos para romper el empate; los demás ven estado pasivo.
+ * Muestra los jugadores empatados con sus dibujos. El impostor recibe un
+ * voto extra que puede depositar en cualquiera de los jugadores empatados
+ * para romper el empate. Su voto original permanece inalterado, por lo que
+ * siempre puede resolver el empate sin delatarse a sí mismo.
  */
 @Component({
   selector: 'app-tie-break-view',
@@ -19,7 +21,6 @@ import { SpectatorCanvasService } from '../../services/spectator-canvas';
 export class TieBreakView {
   readonly state = input.required<GameState>();
   readonly myPlayerId = input<number | null>(null);
-  readonly myPreviousVote = input<number | null>(null);
 
   @Output() voteMoved = new EventEmitter<number>();
 

--- a/frontend/src/app/features/game/components/voting-view/voting-view.html
+++ b/frontend/src/app/features/game/components/voting-view/voting-view.html
@@ -34,15 +34,13 @@
       }
     </div>
   } @else {
-    <p class="instructions">¿Quién crees que es el impostor? Vota tocando una tarjeta.</p>
-
     <div class="vote-grid">
       @for (id of votablePlayers(); track id) {
         <button
           class="vote-card"
-          [class.voted]="myVote() === id"
-          [class.disabled]="myVote() !== null && myVote() !== id"
-          [disabled]="myVote() !== null"
+          [class.voted]="mySelection() === id"
+          [class.disabled]="voteLocked() && mySelection() !== id"
+          [disabled]="voteLocked()"
           [attr.data-testid]="'vote-card-' + id"
           (click)="onVote(id)"
         >
@@ -57,15 +55,19 @@
           } @else {
             <div class="no-drawing">(sin dibujo)</div>
           }
-          @if (myVote() === id) {
-            <div class="vote-marker">✓ Tu voto</div>
+          @if (mySelection() === id) {
+            <div class="vote-marker">{{ voteLocked() ? '✓ Tu voto' : '● Seleccionado' }}</div>
           }
         </button>
       }
     </div>
 
-    @if (myVote() !== null) {
+    @if (voteLocked()) {
       <p class="confirmation">Voto registrado. Esperando al resto…</p>
+    } @else if (mySelection() !== null) {
+      <p class="instructions">Selección actual — puedes cambiar antes de que se bloquee el voto.</p>
+    } @else {
+      <p class="instructions">¿Quién crees que es el impostor? Selecciona una tarjeta.</p>
     }
   }
 </div>

--- a/frontend/src/app/features/game/components/voting-view/voting-view.ts
+++ b/frontend/src/app/features/game/components/voting-view/voting-view.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output, computed, inject, input, signal } from '@angular/core';
+import { Component, EventEmitter, Output, computed, effect, inject, input, signal } from '@angular/core';
 
 import { GameState } from '../../models/game-state';
 import { SpectatorCanvasService } from '../../services/spectator-canvas';
@@ -6,9 +6,10 @@ import { SpectatorCanvasService } from '../../services/spectator-canvas';
 /**
  * 2I.4 — Vista de votación.
  *
- * Tarjetas de jugadores vivos con miniatura del dibujo. Click en una tarjeta
- * emite `voteCast` y bloquea reintentos (un voto por jugador). Excluye a los
- * jugadores ya eliminados (`state.eliminated`).
+ * Tarjetas de jugadores vivos con miniatura del dibujo. El jugador puede
+ * cambiar su selección libremente hasta que el temporizador llegue a
+ * LOCK_SECONDS, momento en el que la selección se envía automáticamente
+ * como voto definitivo y las tarjetas se bloquean.
  */
 @Component({
   selector: 'app-voting-view',
@@ -18,13 +19,30 @@ import { SpectatorCanvasService } from '../../services/spectator-canvas';
   styleUrl: './voting-view.css',
 })
 export class VotingView {
+  private static readonly LOCK_SECONDS = 3;
+
   readonly state = input.required<GameState>();
   readonly myPlayerId = input<number | null>(null);
 
   @Output() voteCast = new EventEmitter<number>();
 
   protected readonly spectator = inject(SpectatorCanvasService);
-  protected readonly myVote = signal<number | null>(null);
+
+  /** Tarjeta actualmente seleccionada (cambiable hasta el bloqueo). */
+  protected readonly mySelection = signal<number | null>(null);
+  /** True después de que el voto se envía automáticamente al servidor. */
+  protected readonly voteLocked = signal(false);
+
+  constructor() {
+    effect(() => {
+      const time = this.state().timeRemainingSec;
+      const selection = this.mySelection();
+      if (time <= VotingView.LOCK_SECONDS && !this.voteLocked() && selection !== null) {
+        this.voteLocked.set(true);
+        this.voteCast.emit(selection);
+      }
+    });
+  }
 
   protected readonly isLocalPlayerEliminated = computed(() => {
     const id = this.myPlayerId();
@@ -41,8 +59,7 @@ export class VotingView {
   }
 
   protected onVote(playerId: number): void {
-    if (this.myVote() !== null) return;
-    this.myVote.set(playerId);
-    this.voteCast.emit(playerId);
+    if (this.voteLocked()) return;
+    this.mySelection.set(playerId);
   }
 }

--- a/frontend/src/app/features/game/components/voting-view/voting-view.ts
+++ b/frontend/src/app/features/game/components/voting-view/voting-view.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output, computed, effect, inject, input, signal } from '@angular/core';
+import { Component, EventEmitter, OnDestroy, OnInit, Output, computed, inject, input, signal } from '@angular/core';
 
 import { GameState } from '../../models/game-state';
 import { SpectatorCanvasService } from '../../services/spectator-canvas';
@@ -10,6 +10,10 @@ import { SpectatorCanvasService } from '../../services/spectator-canvas';
  * cambiar su selección libremente hasta que el temporizador llegue a
  * LOCK_SECONDS, momento en el que la selección se envía automáticamente
  * como voto definitivo y las tarjetas se bloquean.
+ *
+ * El bloqueo se basa en un setTimeout dispuesto en ngOnInit con el tiempo
+ * inicial del servidor (state().timeRemainingSec), ya que ese valor no se
+ * actualiza segundo a segundo en el cliente.
  */
 @Component({
   selector: 'app-voting-view',
@@ -18,7 +22,7 @@ import { SpectatorCanvasService } from '../../services/spectator-canvas';
   templateUrl: './voting-view.html',
   styleUrl: './voting-view.css',
 })
-export class VotingView {
+export class VotingView implements OnInit, OnDestroy {
   private static readonly LOCK_SECONDS = 3;
 
   readonly state = input.required<GameState>();
@@ -33,15 +37,16 @@ export class VotingView {
   /** True después de que el voto se envía automáticamente al servidor. */
   protected readonly voteLocked = signal(false);
 
-  constructor() {
-    effect(() => {
-      const time = this.state().timeRemainingSec;
-      const selection = this.mySelection();
-      if (time <= VotingView.LOCK_SECONDS && !this.voteLocked() && selection !== null) {
-        this.voteLocked.set(true);
-        this.voteCast.emit(selection);
-      }
-    });
+  private lockTimer?: ReturnType<typeof setTimeout>;
+
+  ngOnInit(): void {
+    const totalSeconds = this.state().timeRemainingSec;
+    const delayMs = Math.max(0, (totalSeconds - VotingView.LOCK_SECONDS) * 1000);
+    this.lockTimer = setTimeout(() => this.lockVote(), delayMs);
+  }
+
+  ngOnDestroy(): void {
+    clearTimeout(this.lockTimer);
   }
 
   protected readonly isLocalPlayerEliminated = computed(() => {
@@ -61,5 +66,14 @@ export class VotingView {
   protected onVote(playerId: number): void {
     if (this.voteLocked()) return;
     this.mySelection.set(playerId);
+  }
+
+  private lockVote(): void {
+    if (this.voteLocked()) return;
+    this.voteLocked.set(true);
+    const selection = this.mySelection();
+    if (selection !== null) {
+      this.voteCast.emit(selection);
+    }
   }
 }

--- a/frontend/src/app/features/game/containers/game/game.html
+++ b/frontend/src/app/features/game/containers/game/game.html
@@ -60,7 +60,6 @@
         <app-tie-break-view
           [state]="gameState.state()"
           [myPlayerId]="myPlayerId"
-          [myPreviousVote]="myVotedPlayerId"
           (voteMoved)="sendVoteMove($event)"
         />
       }

--- a/frontend/src/app/features/game/containers/game/game.ts
+++ b/frontend/src/app/features/game/containers/game/game.ts
@@ -170,6 +170,7 @@ export class GameComponent implements OnInit, OnDestroy {
     if (this.connectedToWs) {
       this.ws.disconnect();
     }
+    this.spectator.reset();
     this.gameState.reset();
   }
 

--- a/frontend/src/app/features/game/models/game-state.ts
+++ b/frontend/src/app/features/game/models/game-state.ts
@@ -47,7 +47,7 @@ export interface GameState {
 
 export const INITIAL_STATE: GameState = {
   phase: 'CONNECTING',
-  round: 0,
+  round: 1,
   drawingOrder: [],
   currentDrawerId: null,
   timeRemainingSec: 0,

--- a/frontend/src/app/features/game/services/spectator-canvas.ts
+++ b/frontend/src/app/features/game/services/spectator-canvas.ts
@@ -35,7 +35,7 @@ export class SpectatorCanvasService {
     // Reset automático al inicio de partida o ronda nueva.
     this.gameState.gameEvents$.subscribe((ev) => {
       if (ev.type === 'GAME_START' || ev.type === 'NEW_ROUND') {
-        this.resetAll();
+        this.reset();
       }
     });
   }
@@ -94,7 +94,7 @@ export class SpectatorCanvasService {
   }
 
   /** Resetea todos los canvases (snapshots → {}). */
-  private resetAll(): void {
+  reset(): void {
     this.canvases.clear();
     this._snapshots.set({});
   }


### PR DESCRIPTION
Esta rama corrige seis fallos detectados durante las pruebas de partidas completas en ranked. Los cambios abarcan la sincronización del canvas entre partidas, el flujo de votación, el contador de rondas, el orden de dibujo del impostor y la mecánica de desempate.

---

## Cambios por área

### 1. Dibujos de la partida anterior visibles en la siguiente

Al comenzar una nueva partida, los espectadores veían los dibujos de la partida anterior superpuestos sobre los nuevos. Había dos causas:

- **`WebSocketService.disconnect()` bloqueaba la reconexión**: `deactivate()` es asíncrono y `this.client` seguía apuntando al cliente antiguo. La llamada a `connect()` en la nueva partida encontraba `client.active === true` y retornaba sin crear un cliente nuevo, por lo que `GAME_START` nunca llegaba y `SpectatorCanvasService` nunca se reiniciaba. Solución: se anula `this.client = null` antes de llamar a `deactivate()` y se neutralizan los callbacks del cliente antiguo para que no sobreescriban el estado del nuevo.
- **`SpectatorCanvasService` no se limpiaba al salir de una partida**: el canvas fuera de pantalla conservaba los snapshots aunque el componente se destruyese. Se expuso `reset()` como método público y se llama desde `GameComponent.ngOnDestroy()`.

### 2. Selector de voto libre con bloqueo automático

Antes, un único clic sobre una tarjeta emitía el voto de forma inmediata e irrevocable. Ahora el jugador puede cambiar su selección libremente durante toda la fase de votación. Un `setTimeout` programado en `ngOnInit` bloquea la selección actual y la envía al servidor 3 segundos antes de que expire el temporizador. Si el jugador no ha seleccionado ninguna tarjeta al bloquearse, el servidor aplica el autovoto según las reglas existentes.

> **Nota**: el intento anterior usaba `effect()` sobre `state().timeRemainingSec`, que es un valor puntual del servidor y nunca se decrementa en el cliente, por lo que el bloqueo nunca se activaba y los votos no llegaban al servidor.

### 3. Contador de rondas mostraba «Ronda 0» en la primera ronda

`GAME_START` se publicaba de forma inmediata, antes de que los clientes hubiesen completado la navegación al componente de juego y establecido las suscripciones STOMP. Al no recibir el evento, el campo `round` permanecía en el valor inicial (`0`) del `INITIAL_STATE`. `TURN_START`, que llega tras el retardo de 3 segundos, no actualiza el número de ronda, por lo que la pantalla mostraba «Ronda 0». La segunda ronda mostraba correctamente «Ronda 2» al venir de `NEW_ROUND`.

Solución: `GAME_START` se ha movido al bloque de `scheduler.schedule()` junto con las asignaciones de rol y `TURN_START`, garantizando que todos los clientes están suscritos antes de recibir cualquier evento. Como medida de seguridad adicional, `INITIAL_STATE.round` pasa de `0` a `1`.

### 4. El impostor siempre dibujaba en primer lugar

El código usaba la misma lista barajada para elegir al impostor (`get(0)`) y para construir el orden de dibujo, por lo que el impostor siempre dibujaba primero. Se añade un segundo `Collections.shuffle()` independiente antes de construir el orden de dibujo.

### 5. Mecánica de desempate: voto extra en lugar de mover el voto

La mecánica anterior permitía al impostor «mover» su voto existente a otro jugador empatado. Esto era insoluble cuando el propio impostor era uno de los jugadores empatados: mover el voto equivalía a votarse a sí mismo y ser expulsado, lo cual delataba su identidad si decidía no actuar.

Ahora el impostor recibe **un voto extra** que puede depositar en cualquiera de los jugadores empatados. Su voto original permanece intacto. En el backend, el voto extra se registra con una clave fantasma (`-1L`) para no sobreescribir el voto real del impostor. De esta forma, cualquier configuración de empate es siempre resoluble sin que el impostor se vea forzado a delatarse.

---

## Ficheros modificados

### Backend
| Fichero | Motivo |
|---|---|
| `feature/game/service/GameService.java` | Corrección de asignación de palabra/pista, retardo de `GAME_START`, doble barajado del orden de dibujo, voto extra en desempate |

### Frontend
| Fichero | Motivo |
|---|---|
| `core/services/websocket.service.ts` | Corrección de la carrera asíncrona en `disconnect()` |
| `features/game/services/spectator-canvas.ts` | `reset()` expuesto como método público |
| `features/game/containers/game/game.ts` | Llamada a `spectator.reset()` en `ngOnDestroy()` |
| `features/game/containers/game/game.html` | Eliminado binding `[myPreviousVote]` del `TieBreakView` |
| `features/game/models/game-state.ts` | `INITIAL_STATE.round` de `0` a `1` |
| `features/game/components/voting-view/voting-view.ts` | Selección libre con bloqueo por `setTimeout` |
| `features/game/components/voting-view/voting-view.html` | Actualización de textos e indicadores de estado |
| `features/game/components/tie-break-view/tie-break-view.ts` | Eliminado input `myPreviousVote` |
| `features/game/components/tie-break-view/tie-break-view.html` | Textos e indicadores actualizados para la mecánica de voto extra |