### PR TITLE
Priv game impostor lifes

### DIFF
--- a/backend/src/main/java/com/impaintor/feature/room/controller/RoomController.java
+++ b/backend/src/main/java/com/impaintor/feature/room/controller/RoomController.java
@@ -35,8 +35,18 @@ public class RoomController {
     @Autowired
     private GameService gameService;
 
+    public static class RoomConfigDto {
+        private Integer drawingTime;
+        private Integer impostorLives;
+
+        public Integer getDrawingTime() { return drawingTime; }
+        public void setDrawingTime(Integer drawingTime) { this.drawingTime = drawingTime; }
+        public Integer getImpostorLives() { return impostorLives; }
+        public void setImpostorLives(Integer impostorLives) { this.impostorLives = impostorLives; }
+    }
+
     @PostMapping("/create")
-    public ResponseEntity<?> createRoom() {
+    public ResponseEntity<?> createRoom(@RequestBody(required = false) RoomConfigDto config) {
         Room room = new Room();
 
         Long seed = RandomGenerations.RoomRandomId();
@@ -46,9 +56,19 @@ public class RoomController {
         room.setMode(Room.Mode.CUSTOM);
         room.setGameState(Room.GameState.WAITING);
 
+        if (config != null) {
+            if (config.getDrawingTime() != null) {
+                room.setDrawTime(config.getDrawingTime());
+            }
+            if (config.getImpostorLives() != null) {
+                room.setImpostorTries(config.getImpostorLives());
+            }
+        }
+
         Room saved = roomRepository.save(room);
         return ResponseEntity.ok(saved);
     }
+
 
     @PostMapping("/{code}/join")
     public ResponseEntity<?> joinRoom(@PathVariable String code, @RequestBody User user) {

--- a/frontend/src/app/features/game/components/canvas/canvas.html
+++ b/frontend/src/app/features/game/components/canvas/canvas.html
@@ -82,7 +82,8 @@
       (touchstart)="onTouchStart($event)"
       (touchmove)="onTouchMove($event)"
       (touchend)="onMouseUp()"
-      (touchcancel)="onMouseUp()">
+      (touchcancel)="onMouseUp()"
+      (contextmenu)="$event.preventDefault()">
     </canvas>
   </div>
 </div>

--- a/frontend/src/app/features/game/components/canvas/canvas.ts
+++ b/frontend/src/app/features/game/components/canvas/canvas.ts
@@ -76,6 +76,7 @@ ngOnDestroy(): void {
   // ===== EVENTOS DE DIBUJO (DELEGACIÓN PURA - SRP) =====
 
   onMouseDown(event: MouseEvent): void {
+    if (event.button !== 0) return; // Solo permitir el click izquierdo para dibujar
     if (!this.isActive || !this.engine) return;
     this.engine.processPointerDown(event.clientX, event.clientY);
   }

--- a/frontend/src/app/features/game/components/drawing-phase-view/drawing-phase-view.html
+++ b/frontend/src/app/features/game/components/drawing-phase-view/drawing-phase-view.html
@@ -29,7 +29,7 @@
       </div>
     } @else {
       <div class="spectator" data-testid="spectator-view">
-        <p class="turn-hint">{{ state().currentDrawerId }} está dibujando…</p>
+        <p class="turn-hint">{{ playerNames()[state().currentDrawerId!] || 'Jugador ' + state().currentDrawerId }} está dibujando…</p>
         @if (drawerSnapshot()) {
           <img [src]="drawerSnapshot()" alt="Dibujo en directo" class="spectator-img" />
         } @else {

--- a/frontend/src/app/features/game/components/drawing-phase-view/drawing-phase-view.ts
+++ b/frontend/src/app/features/game/components/drawing-phase-view/drawing-phase-view.ts
@@ -40,6 +40,7 @@ import { SpectatorCanvasService } from '../../services/spectator-canvas';
 export class DrawingPhaseView implements OnInit, OnDestroy {
   readonly state = input.required<GameState>();
   readonly myPlayerId = input<number | null>(null);
+  readonly playerNames = input<Record<number, string>>({});
 
   /** Comando de dibujo (STROKE o CLEAR) listo para reenviar al servidor. */
   @Output() drawCommand = new EventEmitter<DrawCommand>();

--- a/frontend/src/app/features/game/components/game-over-view/game-over-view.css
+++ b/frontend/src/app/features/game/components/game-over-view/game-over-view.css
@@ -12,27 +12,47 @@
   margin-bottom: 1.5rem;
 }
 
-.winner-banner.painters {
-  background: rgba(82, 183, 136, 0.1);
-  border: 2px solid rgba(82, 183, 136, 0.5);
+.winner-banner.victory {
+  background: rgba(74, 124, 89, 0.15);
+  border: 2px solid #4a7c59;
+  box-shadow: 0 0 15px rgba(74, 124, 89, 0.3);
 }
 
-.winner-banner.impostor {
-  background: rgba(124, 77, 255, 0.1);
-  border: 2px solid rgba(124, 77, 255, 0.5);
+.winner-banner.defeat {
+  background: rgba(124, 58, 58, 0.15);
+  border: 2px solid #7c3a3a;
+  box-shadow: 0 0 15px rgba(124, 58, 58, 0.3);
+}
+
+.winner-banner.victory h2 {
+  color: #6fcf97;
+  text-shadow: 0 0 10px rgba(111, 207, 151, 0.4);
+}
+
+.winner-banner.defeat h2 {
+  color: #eb5757;
+  text-shadow: 0 0 10px rgba(235, 87, 87, 0.4);
 }
 
 .winner-banner h2 {
-  margin: 0 0 0.5rem 0;
-  font-family: 'Cinzel', serif;
-  font-size: 1.8rem;
-  color: #c9a86c;
+  margin: 0 0 0.25rem 0;
+  font-family: 'MedievalSharp', 'Cinzel', Georgia, serif;
+  font-size: 2.2rem;
   letter-spacing: 0.04em;
+}
+
+.winner-subtitle {
+  font-family: 'MedievalSharp', 'Cinzel', Georgia, serif;
+  font-size: 1.15rem;
+  color: #f5e6c8;
+  margin: 0 0 0.5rem 0;
+  letter-spacing: 0.02em;
 }
 
 .winner-banner .reason {
   margin: 0;
-  color: #7a5530;
+  color: #d4b896;
+  font-family: 'Kalam', 'Nunito', cursive, sans-serif;
   font-size: 0.95rem;
 }
 

--- a/frontend/src/app/features/game/components/game-over-view/game-over-view.html
+++ b/frontend/src/app/features/game/components/game-over-view/game-over-view.html
@@ -1,9 +1,25 @@
 <div class="game-over-view" data-testid="game-over-phase">
   @if (state.gameOver; as g) {
-    <div class="winner-banner" [class.painters]="g.winner === 'PAINTERS'" [class.impostor]="g.winner === 'IMPOSTOR'">
+    <div class="winner-banner" [class.victory]="hasWon" [class.defeat]="!hasWon">
       <h2 data-testid="winner">
-        @if (g.winner === 'PAINTERS') {
+        @if (hasWon) {
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round" style="width: 1.8rem; height: 1.8rem; vertical-align: -0.2em; margin-right: 0.5rem; display: inline-block;">
+            <circle cx="12" cy="12" r="10"/>
+            <path d="m9 12 2 2 4-4"/>
+          </svg>
+          ¡Victoria!
+        } @else {
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round" style="width: 1.8rem; height: 1.8rem; vertical-align: -0.2em; margin-right: 0.5rem; display: inline-block;">
+            <circle cx="12" cy="12" r="10"/>
+            <path d="m15 9-6 6"/>
+            <path d="m9 9 6 6"/>
+          </svg>
+          ¡Derrota!
+        }
+      </h2>
+      <p class="winner-subtitle">
+        @if (g.winner === 'PAINTERS') {
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round" style="width: 1.4rem; height: 1.4rem; vertical-align: -0.15em; margin-right: 0.4rem; display: inline-block;">
             <path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12c0 2.75 2.25 5 5 5h1a2 2 0 0 1 2 2c0 1.66-1.34 3-3 3-1.66 0-3-1.34-3-3"></path>
             <circle cx="7.5" cy="10.5" r=".5" fill="currentColor"></circle>
             <circle cx="11.5" cy="7.5" r=".5" fill="currentColor"></circle>
@@ -12,14 +28,14 @@
           </svg>
           Ganan los Pintores
         } @else {
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 1.8rem; height: 1.8rem; vertical-align: -0.2em; margin-right: 0.5rem; display: inline-block;">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 1.4rem; height: 1.4rem; vertical-align: -0.15em; margin-right: 0.4rem; display: inline-block;">
             <path d="M2 12a5 5 0 0 0 5 5 8 8 0 0 1 5 2 8 8 0 0 1 5-2 5 5 0 0 0 5-5V7h-5a8 8 0 0 0-8 2 8 8 0 0 0-8-2H2Z"></path>
             <path d="M6 11c1.5 0 3 .5 3 2-2 0-3 0-3-2Z"></path>
             <path d="M18 11c-1.5 0-3 .5-3 2 2 0 3 0 3-2Z"></path>
           </svg>
           Gana el Impostor
         }
-      </h2>
+      </p>
       <p class="reason" data-testid="reason">{{ reasonText(g.reason) }}</p>
     </div>
 
@@ -34,7 +50,7 @@
       </div>
       <div class="reveal-row">
         <dt>Impostor</dt>
-        <dd data-testid="impostor-id">Jugador {{ g.impostorId }}</dd>
+        <dd data-testid="impostor-id">{{ playerNames[g.impostorId] || 'Jugador ' + g.impostorId }}</dd>
       </div>
       <div class="reveal-row">
         <dt>Rondas jugadas</dt>

--- a/frontend/src/app/features/game/components/game-over-view/game-over-view.ts
+++ b/frontend/src/app/features/game/components/game-over-view/game-over-view.ts
@@ -26,7 +26,15 @@ const REASON_TEXT: Record<EndReason, string> = {
 })
 export class GameOverView {
   @Input({ required: true }) state!: GameState;
+  @Input() playerNames: Record<number, string> = {};
   @Output() playAgain = new EventEmitter<void>();
+
+  protected get hasWon(): boolean {
+    if (!this.state || !this.state.gameOver) return false;
+    const winner = this.state.gameOver.winner;
+    const role = this.state.myRole;
+    return (winner === 'PAINTERS' && role === 'PAINTER') || (winner === 'IMPOSTOR' && role === 'IMPOSTOR');
+  }
 
   protected reasonText(reason: EndReason): string {
     return REASON_TEXT[reason];

--- a/frontend/src/app/features/game/components/impostor-overlay/impostor-overlay.css
+++ b/frontend/src/app/features/game/components/impostor-overlay/impostor-overlay.css
@@ -17,16 +17,25 @@
 
   width: 300px;
 
-  background: linear-gradient(135deg, #1a0a2e 0%, #2d1050 60%, #1c2d55 100%);
-  border: 2px solid #7c4dff;
-  border-radius: 16px;
+  background:
+    repeating-linear-gradient(
+      0deg,
+      rgba(255,255,255,0.01) 0px,
+      rgba(255,255,255,0.01) 1px,
+      transparent 1px,
+      transparent 28px
+    ),
+    linear-gradient(160deg, #2e1505 0%, #3d1f08 30%, #2a1203 70%, #1e0c02 100%);
+  border: 2px solid #5c3a1e;
+  border-radius: 10px;
   box-shadow:
-    0 8px 32px rgba(124, 77, 255, 0.4),
-    0 2px 8px rgba(0, 0, 0, 0.5),
-    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    0 0 0 3px #1a0e05,
+    0 0 0 5px #3d2208,
+    0 12px 32px rgba(0, 0, 0, 0.85),
+    inset 0 1px 0 rgba(255, 200, 100, 0.08);
 
-  color: #f0e6ff;
-  font-family: var(--font-body, 'Nunito', sans-serif);
+  color: #f5e6c8;
+  font-family: 'Kalam', 'Nunito', cursive, sans-serif;
 
   /* Smooth entrance */
   animation: slide-in 0.35s cubic-bezier(0.34, 1.56, 0.64, 1) both;
@@ -42,10 +51,12 @@
 
 /* Out-of-lives state — red border pulse */
 .impostor-overlay.out-of-lives {
-  border-color: #e84545;
+  border-color: #7c3a3a;
   box-shadow:
-    0 8px 32px rgba(232, 69, 69, 0.45),
-    0 2px 8px rgba(0, 0, 0, 0.5);
+    0 0 0 3px #1a0e05,
+    0 0 0 5px #5c2222,
+    0 12px 32px rgba(124, 58, 58, 0.45),
+    inset 0 1px 0 rgba(255, 100, 100, 0.08);
   animation: pulse-red 2s ease infinite;
 }
 
@@ -60,7 +71,7 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 1rem 0.6rem;
-  border-bottom: 1px solid rgba(124, 77, 255, 0.35);
+  border-bottom: 1px solid #5c3a1e;
   cursor: default;
 }
 
@@ -69,23 +80,24 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  color: #d0b4ff;
+  color: #c9a86c;
 }
 
 .overlay-title {
-  font-family: var(--font-display, 'Baloo 2', cursive);
+  font-family: 'MedievalSharp', 'Cinzel', Georgia, serif;
   font-weight: 700;
-  font-size: 0.95rem;
+  font-size: 1rem;
   letter-spacing: 0.02em;
-  color: #d0b4ff;
+  color: #f5e6c8;
+  text-shadow: 1px 1px 0 #3a1a00;
   flex: 1;
 }
 
 .minimize-btn {
-  background: rgba(124, 77, 255, 0.2);
-  border: 1px solid rgba(124, 77, 255, 0.4);
+  background: rgba(201, 168, 108, 0.1);
+  border: 1px solid #5c3a1e;
   border-radius: 6px;
-  color: #d0b4ff;
+  color: #c9a86c;
   padding: 0.25rem;
   display: flex;
   align-items: center;
@@ -97,8 +109,9 @@
 }
 
 .minimize-btn:hover {
-  background: rgba(124, 77, 255, 0.4);
+  background: rgba(201, 168, 108, 0.25);
   transform: scale(1.1);
+  color: #f5e6c8;
 }
 
 /* ── Body ────────────────────────────────────────────────────── */
@@ -119,19 +132,20 @@
 .hint-label,
 .lives-label,
 .guess-label {
-  font-size: 0.7rem;
+  font-family: 'MedievalSharp', 'Cinzel', serif;
+  font-size: 0.75rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: rgba(208, 180, 255, 0.65);
+  color: #c9a86c;
 }
 
 .hint-value {
-  font-family: var(--font-display, 'Baloo 2', cursive);
-  font-size: 1.35rem;
+  font-family: 'MedievalSharp', 'Cinzel', Georgia, serif;
+  font-size: 1.45rem;
   font-weight: 800;
   color: #f5a623;
-  text-shadow: 0 0 12px rgba(245, 166, 35, 0.5);
+  text-shadow: 0 0 12px rgba(245, 166, 35, 0.5), 1px 1px 0 #1a0e05;
   letter-spacing: 0.03em;
   word-break: break-word;
 }
@@ -162,9 +176,10 @@
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  font-size: 0.9rem;
+  font-family: 'MedievalSharp', 'Cinzel', serif;
+  font-size: 0.85rem;
   font-weight: 700;
-  color: #e84545;
+  color: #eb5757;
 }
 
 /* ── Guess input ─────────────────────────────────────────────── */
@@ -181,11 +196,11 @@
 
 .guess-input {
   flex: 1;
-  background: rgba(255, 255, 255, 0.07);
-  border: 1.5px solid rgba(124, 77, 255, 0.45);
-  border-radius: 8px;
-  color: #f0e6ff;
-  font-family: var(--font-body, 'Nunito', sans-serif);
+  background: rgba(0, 0, 0, 0.3);
+  border: 1.5px solid #5c3a1e;
+  border-radius: 6px;
+  color: #f5e6c8;
+  font-family: 'Kalam', 'Nunito', cursive, sans-serif;
   font-size: 0.875rem;
   padding: 0.45rem 0.7rem;
   outline: none;
@@ -196,14 +211,14 @@
 }
 
 .guess-input::placeholder {
-  color: rgba(208, 180, 255, 0.4);
+  color: #8b6040;
   font-style: italic;
 }
 
 .guess-input:focus {
-  border-color: #7c4dff;
-  background: rgba(255, 255, 255, 0.11);
-  box-shadow: 0 0 0 3px rgba(124, 77, 255, 0.25);
+  border-color: #c9a86c;
+  background: rgba(0, 0, 0, 0.45);
+  box-shadow: 0 0 0 3px rgba(201, 168, 108, 0.2);
 }
 
 .guess-input:disabled {
@@ -212,26 +227,29 @@
 }
 
 .guess-btn {
-  background: linear-gradient(135deg, #7c4dff, #5c2de0);
+  background: #c9a86c;
   border: none;
-  border-radius: 8px;
-  color: #fff;
-  font-family: var(--font-body, 'Nunito', sans-serif);
-  font-size: 0.8rem;
-  font-weight: 800;
+  border-radius: 6px;
+  color: #1a0e05;
+  font-family: 'MedievalSharp', 'Cinzel', serif;
+  font-size: 0.85rem;
+  font-weight: 700;
   letter-spacing: 0.03em;
   padding: 0.45rem 0.85rem;
   cursor: pointer !important;
+  box-shadow: 0 4px 10px rgba(201, 168, 108, 0.25);
   transition:
     transform 0.15s,
     box-shadow 0.15s,
+    background 0.2s,
     opacity 0.2s;
   white-space: nowrap;
 }
 
 .guess-btn:hover:not(:disabled) {
+  background: #e0c28b;
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(124, 77, 255, 0.5);
+  box-shadow: 0 4px 12px rgba(201, 168, 108, 0.4);
 }
 
 .guess-btn:active:not(:disabled) {
@@ -246,7 +264,7 @@
 .no-lives-msg {
   margin: 0;
   font-size: 0.75rem;
-  color: #e84545;
+  color: #eb5757;
   font-style: italic;
 }
 
@@ -273,8 +291,8 @@
 }
 
 @keyframes pulse-red {
-  0%, 100% { box-shadow: 0 8px 32px rgba(232, 69, 69, 0.45), 0 2px 8px rgba(0,0,0,0.5); }
-  50%       { box-shadow: 0 8px 40px rgba(232, 69, 69, 0.7),  0 2px 8px rgba(0,0,0,0.5); }
+  0%, 100% { box-shadow: 0 0 0 3px #1a0e05, 0 0 0 5px #5c2222, 0 12px 32px rgba(124, 58, 58, 0.45); }
+  50%       { box-shadow: 0 0 0 3px #1a0e05, 0 0 0 5px #7c3a3a, 0 12px 40px rgba(124, 58, 58, 0.7); }
 }
 
 @keyframes heart-pop {

--- a/frontend/src/app/features/game/components/tie-break-view/tie-break-view.html
+++ b/frontend/src/app/features/game/components/tie-break-view/tie-break-view.html
@@ -27,7 +27,7 @@
           (click)="onCardClick(entry.id)"
         >
           <div class="player-label">
-            Jugador {{ entry.id }}
+            {{ playerNames()[entry.id] || 'Jugador ' + entry.id }}
             @if (entry.id === myPlayerId()) {
               <span class="self-marker">(Tú)</span>
             }
@@ -59,7 +59,7 @@
     <div class="vote-grid readonly">
       @for (entry of state().tiedPlayers; track entry.id) {
         <div class="vote-card tied-readonly" [attr.data-testid]="'tied-card-' + entry.id">
-          <div class="player-label">Jugador {{ entry.id }}</div>
+          <div class="player-label">{{ playerNames()[entry.id] || 'Jugador ' + entry.id }}</div>
 
           <div class="vote-count-badge">{{ entry.votes }} voto(s)</div>
 

--- a/frontend/src/app/features/game/components/tie-break-view/tie-break-view.ts
+++ b/frontend/src/app/features/game/components/tie-break-view/tie-break-view.ts
@@ -21,6 +21,7 @@ import { SpectatorCanvasService } from '../../services/spectator-canvas';
 export class TieBreakView {
   readonly state = input.required<GameState>();
   readonly myPlayerId = input<number | null>(null);
+  readonly playerNames = input<Record<number, string>>({});
 
   @Output() voteMoved = new EventEmitter<number>();
 

--- a/frontend/src/app/features/game/components/vote-result-view/vote-result-view.html
+++ b/frontend/src/app/features/game/components/vote-result-view/vote-result-view.html
@@ -11,7 +11,7 @@
     <div class="elimination-result">
       <p>
         Jugador eliminado:
-        <strong data-testid="eliminated-player-id">{{ state.eliminated }}</strong>
+        <strong data-testid="eliminated-player-id">{{ playerNames[state.eliminated] || 'Jugador ' + state.eliminated }}</strong>
       </p>
       @if (state.wasImpostorEliminated) {
         <p class="impostor-reveal was-impostor" data-testid="was-impostor-message">
@@ -30,7 +30,7 @@
     <ul class="top-voted-list" data-testid="top-voted-list">
       @for (entry of state.topVoted; track entry.id) {
         <li [attr.data-testid]="'top-voted-entry-' + entry.id">
-          Jugador {{ entry.id }} — {{ entry.votes }} voto(s)
+          {{ playerNames[entry.id] || 'Jugador ' + entry.id }} — {{ entry.votes }} voto(s)
         </li>
       }
     </ul>

--- a/frontend/src/app/features/game/components/vote-result-view/vote-result-view.ts
+++ b/frontend/src/app/features/game/components/vote-result-view/vote-result-view.ts
@@ -17,4 +17,5 @@ import { GameState } from '../../models/game-state';
 })
 export class VoteResultView {
   @Input({ required: true }) state!: GameState;
+  @Input() playerNames: Record<number, string> = {};
 }

--- a/frontend/src/app/features/game/components/voting-view/voting-view.html
+++ b/frontend/src/app/features/game/components/voting-view/voting-view.html
@@ -24,7 +24,7 @@
     <div class="vote-grid">
       @for (id of votablePlayers(); track id) {
         <div class="vote-card spectator" [attr.data-testid]="'vote-card-' + id">
-          <div class="player-label">Jugador {{ id }}</div>
+          <div class="player-label">{{ playerNames()[id] || 'Jugador ' + id }}</div>
           @if (snapshotFor(id); as src) {
             <img [src]="src" alt="Dibujo del jugador {{ id }}" class="vote-thumb" />
           } @else {
@@ -45,7 +45,7 @@
           (click)="onVote(id)"
         >
           <div class="player-label">
-            Jugador {{ id }}
+            {{ playerNames()[id] || 'Jugador ' + id }}
             @if (id === myPlayerId()) {
               <span class="self-marker" data-testid="self-marker">(Tú)</span>
             }

--- a/frontend/src/app/features/game/components/voting-view/voting-view.ts
+++ b/frontend/src/app/features/game/components/voting-view/voting-view.ts
@@ -27,6 +27,7 @@ export class VotingView implements OnInit, OnDestroy {
 
   readonly state = input.required<GameState>();
   readonly myPlayerId = input<number | null>(null);
+  readonly playerNames = input<Record<number, string>>({});
 
   @Output() voteCast = new EventEmitter<number>();
 

--- a/frontend/src/app/features/game/containers/game/game.html
+++ b/frontend/src/app/features/game/containers/game/game.html
@@ -42,6 +42,7 @@
         <app-drawing-phase-view
           [state]="gameState.state()"
           [myPlayerId]="myPlayerId"
+          [playerNames]="playerNames()"
           (drawCommand)="sendDraw($event)"
           (guessSubmitted)="sendGuess($event)"
         />
@@ -53,6 +54,7 @@
         <app-voting-view
           [state]="gameState.state()"
           [myPlayerId]="myPlayerId"
+          [playerNames]="playerNames()"
           (voteCast)="sendVote($event)"
         />
       }
@@ -60,15 +62,20 @@
         <app-tie-break-view
           [state]="gameState.state()"
           [myPlayerId]="myPlayerId"
+          [playerNames]="playerNames()"
           (voteMoved)="sendVoteMove($event)"
         />
       }
       @case ('RESULT') {
-        <app-vote-result-view [state]="gameState.state()" />
+        <app-vote-result-view
+          [state]="gameState.state()"
+          [playerNames]="playerNames()"
+        />
       }
       @case ('OVER') {
         <app-game-over-view
           [state]="gameState.state()"
+          [playerNames]="playerNames()"
           (playAgain)="onPlayAgain()"
         />
       }

--- a/frontend/src/app/features/game/containers/game/game.ts
+++ b/frontend/src/app/features/game/containers/game/game.ts
@@ -1,6 +1,7 @@
-import { Component, OnDestroy, OnInit, ViewChild, computed, effect, inject } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewChild, computed, effect, inject, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subject, takeUntil } from 'rxjs';
+import { HttpClient } from '@angular/common/http';
 
 import { GameStateService } from '../../services/game-state';
 import { MockGameEventEmitter } from '../../services/mock-game-event-emitter';
@@ -53,6 +54,7 @@ export class GameComponent implements OnInit, OnDestroy {
   private readonly ws = inject(WebSocketService);
   private readonly authService = inject(AuthService);
   private readonly mock = inject(MockGameEventEmitter);
+  private readonly http = inject(HttpClient);
   readonly gameState = inject(GameStateService);
   // Inyectado para que el servicio se construya y se subscriba a gameEvents$
   private readonly spectator = inject(SpectatorCanvasService);
@@ -110,6 +112,9 @@ export class GameComponent implements OnInit, OnDestroy {
   /** True si estamos usando el emitter mock (modo dev). */
   devMode = false;
 
+  /** Mapa de nombres de usuario asociados al ID de jugador. */
+  protected readonly playerNames = signal<Record<number, string>>({});
+
   private readonly destroy$ = new Subject<void>();
   private connectedToWs = false;
 
@@ -136,6 +141,8 @@ export class GameComponent implements OnInit, OnDestroy {
     const code = this.route.snapshot.paramMap.get('code') ?? '';
     this.devMode = this.route.snapshot.queryParamMap.get('dev') === 'true';
 
+    this.loadRoomPlayers(code);
+
     if (this.devMode) {
       this.myPlayerId = 42;
       this.wireMockEmitter();
@@ -161,6 +168,32 @@ export class GameComponent implements OnInit, OnDestroy {
     if (user) this.myPlayerId = user.id;
 
     this.connectWebSocket(code, token);
+  }
+
+  private loadRoomPlayers(code: string): void {
+    if (this.devMode) {
+      this.playerNames.set({
+        42: this.authService.getCurrentUser()?.username ?? 'Tú',
+        1: 'Pintor Velázquez',
+        2: 'Pintor Goya',
+        3: 'Pintor Picasso',
+        4: 'Pintor Dalí'
+      });
+      return;
+    }
+
+    this.http.get<any>(`/api/rooms/${code}`).subscribe({
+      next: (room) => {
+        if (room && room.playersNames) {
+          const map: Record<number, string> = {};
+          room.playersNames.forEach((p: any) => {
+            map[p.id] = p.username;
+          });
+          this.playerNames.set(map);
+        }
+      },
+      error: (err) => console.error('[Game] Error loading player names:', err)
+    });
   }
 
   ngOnDestroy(): void {

--- a/frontend/src/app/features/home/components/game-menu/game-menu.component.css
+++ b/frontend/src/app/features/home/components/game-menu/game-menu.component.css
@@ -175,8 +175,8 @@
 .popup-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(3px);
+  background: rgba(0, 0, 0, 0.78);
+  backdrop-filter: blur(4px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -184,14 +184,26 @@
 }
 
 .popup-content {
-  background: #fdf8ee;
-  border: 3px solid #ddd4b8;
-  border-radius: 12px;
-  padding: 2rem;
+  background:
+    repeating-linear-gradient(
+      0deg,
+      rgba(255,255,255,0.012) 0px,
+      rgba(255,255,255,0.012) 1px,
+      transparent 1px,
+      transparent 28px
+    ),
+    linear-gradient(160deg, #2e1505 0%, #3d1f08 30%, #2a1203 70%, #1e0c02 100%);
+  border: 2px solid #5c3a1e;
+  border-radius: 8px;
+  box-shadow:
+    0 0 0 4px #1a0e05,
+    0 0 0 6px #3d2208,
+    0 24px 64px rgba(0,0,0,0.85),
+    inset 0 1px 0 rgba(255,200,100,0.08);
+  padding: 2.2rem;
   width: 90%;
   max-width: 400px;
   position: relative;
-  box-shadow: 0 15px 35px rgba(0,0,0,0.4);
   text-align: center;
 }
 
@@ -203,55 +215,59 @@
   border: none;
   font-size: 1.8rem;
   cursor: pointer;
-  color: #777;
+  color: #c9a86c;
   transition: color 0.2s;
 }
 
 .popup-close:hover {
-  color: #c0392b;
+  color: #eb5757;
 }
 
 .popup-content h3 {
-  font-family: 'Bangers', cursive;
-  font-size: 2rem;
-  color: #1a0e06;
-  margin-bottom: 0.5rem;
+  font-family: 'MedievalSharp', 'Cinzel', Georgia, serif;
+  font-size: 1.6rem;
+  color: #f5e6c8;
+  text-shadow: 2px 2px 0 #3a1a00, 0 0 20px rgba(255,180,60,0.35);
+  margin-bottom: 0.75rem;
 }
 
 .popup-content p {
-  font-family: 'Kalam', cursive;
-  color: #555;
+  font-family: 'Kalam', 'Nunito', cursive, sans-serif;
+  color: #d4b896;
   margin-bottom: 1.5rem;
-  font-size: 1.1rem;
+  font-size: 1rem;
+  line-height: 1.5;
 }
 
 .room-code-input {
   width: 100%;
-  padding: 1rem;
-  font-family: 'Kalam', cursive;
+  padding: 0.8rem;
+  font-family: 'MedievalSharp', 'Cinzel', serif;
   font-size: 1.5rem;
-  border: 2px solid #8b5e2a;
-  border-radius: 8px;
-  background: #fff;
+  font-weight: 700;
+  border: 2.5px solid #5c3a1e;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.3);
   text-align: center;
   letter-spacing: 4px;
   text-transform: uppercase;
-  color: #3d1f00;
-  box-shadow: inset 0 3px 8px rgba(0,0,0,0.15);
+  color: #f5e6c8;
+  box-shadow: inset 0 3px 8px rgba(0,0,0,0.4);
   transition: all 0.2s;
   margin-bottom: 1.5rem;
 }
 
 .room-code-input:focus {
   outline: none;
-  border-color: #c9a032;
-  box-shadow: inset 0 3px 8px rgba(0,0,0,0.1), 0 0 0 3px rgba(201, 160, 50, 0.4);
+  border-color: #c9a86c;
+  background: rgba(0, 0, 0, 0.45);
+  box-shadow: inset 0 3px 8px rgba(0,0,0,0.4), 0 0 0 3px rgba(201, 168, 108, 0.2);
 }
 
 .room-code-input::placeholder {
   text-transform: none;
   letter-spacing: normal;
-  color: #a99684;
+  color: #8b6040;
 }
 
 .popup-actions {
@@ -261,30 +277,46 @@
 
 .popup-actions button {
   flex: 1;
-  padding: 0.8rem;
-  border-radius: 8px;
-  font-family: 'Bangers', cursive;
-  font-size: 1.2rem;
+  padding: 0.75rem;
+  border-radius: 4px;
+  font-family: 'MedievalSharp', 'Cinzel', serif;
+  font-size: 1.05rem;
+  font-weight: 700;
   cursor: pointer;
-  transition: transform 0.2s, filter 0.2s;
+  transition: transform 0.15s, background 0.15s, box-shadow 0.15s;
   text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .popup-actions .btn-cancel {
-  background-color: #e0e0e0;
-  color: #333;
-  border: 2px solid #ccc;
+  background-color: transparent;
+  color: #c9a86c;
+  border: 1px solid #5c3a1e;
 }
 
 .popup-actions .btn-submit {
-  background-color: #e67e22;
-  color: #fff;
-  border: 2px solid #d35400;
+  background-color: #c9a86c;
+  color: #1a0e05;
+  border: none;
+  box-shadow: 0 4px 10px rgba(201,168,108,0.25);
 }
 
-.popup-actions .btn-cancel:hover { filter: brightness(0.9); }
-.popup-actions .btn-submit:hover:not(:disabled) { filter: brightness(1.1); transform: translateY(-2px); }
-.popup-actions .btn-submit:disabled { opacity: 0.6; cursor: not-allowed; }
+.popup-actions .btn-cancel:hover {
+  background: rgba(201,168,108,0.1);
+  transform: translateY(-1px);
+}
+
+.popup-actions .btn-submit:hover:not(:disabled) {
+  background-color: #e0c28b;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(201,168,108,0.4);
+}
+.popup-actions .btn-submit:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: none !important;
+  box-shadow: none !important;
+}
 
 /* ---- Partes del botón ---- */
 .menu-btn__icon {

--- a/frontend/src/app/features/home/components/home-footer/home-footer.component.ts
+++ b/frontend/src/app/features/home/components/home-footer/home-footer.component.ts
@@ -12,11 +12,19 @@ import { Component } from '@angular/core';
   standalone: true,
   template: `
     <footer class="home-footer" role="contentinfo">
-      <div class="footer-ornament" aria-hidden="true">⚜</div>
+      <div class="footer-ornament" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round" style="width: 0.95rem; height: 0.95rem; display: inline-block; color: #5c3a1e; vertical-align: middle;">
+          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+        </svg>
+      </div>
       <p class="footer-text">
         Impaintor &copy; 2026 — Dibuja. Engaña. Descubre.
       </p>
-      <div class="footer-ornament" aria-hidden="true">⚜</div>
+      <div class="footer-ornament" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round" style="width: 0.95rem; height: 0.95rem; display: inline-block; color: #5c3a1e; vertical-align: middle;">
+          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+        </svg>
+      </div>
     </footer>
   `,
   styleUrl: './home-footer.component.css',

--- a/frontend/src/app/features/home/home.component.css
+++ b/frontend/src/app/features/home/home.component.css
@@ -26,8 +26,9 @@
   border: 2px solid #5f3b1d;
   background: linear-gradient(160deg, #3a220e 0%, #261307 100%);
   color: #d9b67a;
-  font-size: 1.5rem;
-  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
   z-index: 30;
   box-shadow:

--- a/frontend/src/app/features/home/home.component.html
+++ b/frontend/src/app/features/home/home.component.html
@@ -16,7 +16,10 @@
     title="Perfil"
     (click)="goToProfile()"
   >
-    ⚙
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 1.35rem; height: 1.35rem;" aria-hidden="true">
+      <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.1a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/>
+      <circle cx="12" cy="12" r="3"/>
+    </svg>
   </button>
 
   <!-- Botón de información del juego -->

--- a/frontend/src/app/features/matchmaking/matchmaking.component.css
+++ b/frontend/src/app/features/matchmaking/matchmaking.component.css
@@ -167,11 +167,18 @@
 .status-icon {
   font-size: 1rem;
   line-height: 1;
+  color: #c9a86c;
 }
 
 .status-text {
   font-size: 0.95rem;
   color: #f5e6c8;
+}
+
+.timer-text {
+  color: #c9a86c;
+  font-weight: 700;
+  text-shadow: 0 0 8px rgba(201, 168, 108, 0.2);
 }
 
 /* ---- Error ---- */

--- a/frontend/src/app/features/matchmaking/matchmaking.component.html
+++ b/frontend/src/app/features/matchmaking/matchmaking.component.html
@@ -37,7 +37,7 @@
               <polyline points="12 6 12 12 16 14"></polyline>
             </svg>
           </span>
-          <span class="status-text">{{ formatTime(waitSeconds()) }}</span>
+          <span class="status-text timer-text">{{ formatTime(waitSeconds()) }}</span>
         </div>
         <div class="status-row">
           <span class="status-icon" aria-hidden="true" style="display: inline-flex; align-items: center; justify-content: center; vertical-align: middle; margin-right: 0.4rem;">

--- a/frontend/src/app/features/room/create/create-room.component.css
+++ b/frontend/src/app/features/room/create/create-room.component.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Caveat:wght@700&family=Kalam:wght@400;700&family=Bangers&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=MedievalSharp&family=Cinzel:wght@400;700&family=Nunito:wght@500;600;700;800;900&display=swap');
 
 .create-room-container {
   display: flex;
@@ -8,35 +8,46 @@
   padding: 2rem;
   position: relative;
   overflow: hidden;
-  font-family: 'Kalam', cursive;
+  font-family: 'Nunito', sans-serif;
 }
 
-
-
 .create-room-card {
-  background: #fdf8ee;
-  border-radius: 12px;
+  background:
+    repeating-linear-gradient(
+      0deg,
+      rgba(255, 255, 255, 0.012) 0px,
+      rgba(255, 255, 255, 0.012) 1px,
+      transparent 1px,
+      transparent 28px
+    ),
+    linear-gradient(160deg, #2e1505 0%, #3d1f08 30%, #2a1203 70%, #1e0c02 100%);
+  border: 2px solid #5c3a1e;
+  border-radius: 8px;
+  box-shadow:
+    0 0 0 4px #1a0e05,
+    0 0 0 6px #3d2208,
+    0 24px 64px rgba(0, 0, 0, 0.85),
+    inset 0 1px 0 rgba(255, 200, 100, 0.08);
   padding: 2.5rem;
   width: 100%;
   max-width: 480px;
-  box-shadow: 0 15px 35px rgba(0,0,0,0.4);
-  border: 3px solid #ddd4b8;
 }
 
 .title {
-  font-family: 'Bangers', cursive;
+  font-family: 'MedievalSharp', 'Cinzel', Georgia, serif;
   text-align: center;
-  color: #1a0e06;
-  font-size: 2.5rem;
+  color: #f5e6c8;
+  font-size: 2.2rem;
   margin-bottom: 2rem;
   letter-spacing: 2px;
   text-transform: uppercase;
+  text-shadow: 2px 2px 0 #3a1a00, 0 0 20px rgba(255,180,60,0.35);
 }
 
 .title small {
-  font-family: 'Kalam', cursive;
-  font-size: 1.3rem;
-  color: #555;
+  font-family: 'Nunito', sans-serif;
+  font-size: 1.1rem;
+  color: #c9a86c;
   display: block;
   letter-spacing: normal;
   text-transform: none;
@@ -56,45 +67,50 @@
 }
 
 label {
-  font-size: 1.25rem;
+  font-family: 'MedievalSharp', 'Cinzel', Georgia, serif;
+  font-size: 1.15rem;
   font-weight: 700;
-  color: #333;
+  color: #c9a86c;
+  letter-spacing: 0.02em;
 }
 
 .en-subtitle {
   display: block;
-  font-size: 0.95rem;
-  color: #777;
+  font-size: 0.85rem;
+  color: #8b6040;
   font-weight: normal;
 }
 
 .form-control {
   padding: 0.8rem 1rem;
-  font-family: 'Kalam', cursive;
+  font-family: 'Nunito', sans-serif;
   font-size: 1.15rem;
-  border: 2px solid #ccc;
-  border-radius: 8px;
-  background: #fff;
+  border: 2px solid #5c3a1e;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.3);
+  color: #f5e6c8;
   transition: border-color 0.3s, box-shadow 0.3s;
 }
 
 .form-control:focus {
-  border-color: #e67e22;
-  box-shadow: 0 0 0 3px rgba(230, 126, 34, 0.2);
+  border-color: #c9a86c;
+  background: rgba(0, 0, 0, 0.45);
+  box-shadow: 0 0 0 3px rgba(201, 168, 108, 0.2);
   outline: none;
 }
 
 .error-msg {
-  color: #c0392b;
-  font-size: 0.95rem;
+  color: #eb5757;
+  font-size: 0.88rem;
   display: block;
 }
 
 .error-alert {
-  background-color: #fadbd8;
-  color: #c0392b;
+  background-color: rgba(124, 58, 58, 0.2);
+  color: #eb5757;
+  border: 1px solid #7c3a3a;
   padding: 1rem;
-  border-radius: 8px;
+  border-radius: 6px;
   text-align: center;
   font-weight: 700;
 }
@@ -108,44 +124,50 @@ label {
 .btn-cancel, .btn-submit {
   flex: 1;
   padding: 0.8rem;
-  border-radius: 8px;
-  font-family: 'Bangers', cursive;
-  font-size: 1.4rem;
+  border-radius: 4px;
+  font-family: 'MedievalSharp', 'Cinzel', Georgia, serif;
+  font-size: 1.15rem;
+  font-weight: 700;
   cursor: pointer;
-  transition: transform 0.2s, filter 0.2s;
+  transition: transform 0.15s, background 0.15s, box-shadow 0.15s;
   text-transform: uppercase;
   letter-spacing: 1px;
 }
 
 .btn-cancel {
-  background-color: #e0e0e0;
-  color: #333;
-  border: 2px solid #ccc;
+  background-color: transparent;
+  color: #c9a86c;
+  border: 1px solid #5c3a1e;
 }
 
 .btn-submit {
-  background-color: #e67e22;
-  color: #fff;
-  border: 2px solid #d35400;
+  background-color: #c9a86c;
+  color: #1a0e05;
+  border: none;
+  box-shadow: 0 4px 10px rgba(201,168,108,0.25);
 }
 
 .btn-cancel:hover {
-  filter: brightness(0.9);
+  background: rgba(201,168,108,0.1);
+  transform: translateY(-1px);
 }
 
 .btn-submit:hover:not(:disabled) {
-  filter: brightness(1.1);
+  background-color: #e0c28b;
   transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(201,168,108,0.4);
 }
 
 .btn-submit:disabled {
-  opacity: 0.6;
+  opacity: 0.4;
   cursor: not-allowed;
+  transform: none !important;
+  box-shadow: none !important;
 }
 
 .btn-cancel small, .btn-submit small {
-  font-family: 'Kalam', cursive;
-  font-size: 0.9rem;
+  font-family: 'Nunito', sans-serif;
+  font-size: 0.8rem;
   display: block;
   text-transform: none;
   letter-spacing: normal;
@@ -164,6 +186,4 @@ label {
 @keyframes spin {
   to { transform: rotate(360deg); }
 }
-
-/* hola */
 

--- a/frontend/src/app/features/room/create/create-room.component.html
+++ b/frontend/src/app/features/room/create/create-room.component.html
@@ -11,7 +11,6 @@
       <div class="form-group">
         <label for="drawingTime">
           Tiempo de dibujo por turno (seg.)
-          <span class="en-subtitle">Drawing time per turn (sec.)</span>
         </label>
         <input
           id="drawingTime"
@@ -32,7 +31,6 @@
       <div class="form-group">
         <label for="impostorLives">
           Vidas del Impostor
-          <span class="en-subtitle">Impostor lives</span>
         </label>
         <input
           id="impostorLives"
@@ -56,10 +54,10 @@
 
       <div class="form-actions">
         <button type="button" class="btn-cancel" (click)="cancel()" [disabled]="isLoading">
-          Cancelar<br><small>Cancel</small>
+          Cancelar<br>
         </button>
         <button type="submit" class="btn-submit" [disabled]="roomForm.invalid || isLoading">
-          <span *ngIf="!isLoading">Crear Sala<br><small>Create Room</small></span>
+          <span *ngIf="!isLoading">Crear Sala<br></span>
           <span *ngIf="isLoading" class="loader"></span>
         </button>
       </div>

--- a/frontend/src/app/features/room/lobby/lobby.ts
+++ b/frontend/src/app/features/room/lobby/lobby.ts
@@ -80,6 +80,12 @@ export class Lobby implements OnInit, OnDestroy {
           room.playersNames.map((u, index) => ({ username: u.username, isHost: index === 0 }))
         );
 
+        // Update the room config signal
+        this.roomConfig.set({
+          drawingTime: room.drawTime || 30,
+          impostorLives: room.impostorTries || 1
+        });
+
         const currentUser = this.authService.getCurrentUser();
         if (currentUser && room.playersNames.length > 0 && room.playersNames[0].username === currentUser.username) {
           this.isHost.set(true);
@@ -113,6 +119,12 @@ export class Lobby implements OnInit, OnDestroy {
               this.isHost.set(false);
             }
           }
+
+          // Update the room config signal
+          this.roomConfig.set({
+            drawingTime: room.drawTime || 30,
+            impostorLives: room.impostorTries || 1
+          });
         },
       });
 
@@ -134,6 +146,12 @@ export class Lobby implements OnInit, OnDestroy {
           if (room.gameState === 'PLAYING') {
             this.navigateToGame();
           }
+
+          // Update the room config signal
+          this.roomConfig.set({
+            drawingTime: room.drawTime || 30,
+            impostorLives: room.impostorTries || 1
+          });
         },
       });
     }, 3000);


### PR DESCRIPTION
## Esta PR va después de #61. Revisar después de la Pull Request #61.

## **Backend: Flexibilidad en la Creación de Salas y Solución a las Vidas del Impostor**
- Se añadió soporte para enviar una configuración personalizada de la sala (tiempo de dibujo y vidas del impostor) al crear una sala mediante la API. Esto se consigue introduciendo `RoomConfigDto` y actualizando el endpoint `createRoom` para aceptar y aplicar estos ajustes cuando se proporcionan. [[1]](diffhunk://#diff-5ed6148f1f6b3e24fdec60bcfe1fe92ba9a22bd7831874a453d35c67848de2fcR38-R49) [[2]](diffhunk://#diff-5ed6148f1f6b3e24fdec60bcfe1fe92ba9a22bd7831874a453d35c67848de2fcR59-R72)
- Esto soluciona directamente el bug por el cual las vidas del impostor siempre se iniciaban en 1 en lugar de respetar la configuración de partida privada establecida por el usuario.

## **Lobby: Sincronización y Visualización de Ajustes**
- Se actualizó el componente `Lobby` en Angular para poblar y actualizar la señal `roomConfig` en el ciclo de vida inicial de la petición HTTP, en el canal de suscripción de WebSockets y en el fallback del polling HTTP. Esto asegura que todos los jugadores en la sala visualicen correctamente los ajustes del juego (tiempo de dibujo y vidas del impostor) configurados por el anfitrión.

## **Interfaz de Usuario: Reemplazo de Emojis por Iconos SVG Profesionales**
- Se eliminaron los emojis de texto genéricos y se sustituyeron por gráficos vectoriales vectoriales modernos (SVGs) acordes a la temática rústica/medieval del juego:
  - En la vista principal (`HomeComponent`), el emoji del engranaje (`⚙`) en el botón de perfil se reemplazó por un SVG limpio de engranaje de configuración, centrando el icono con Flexbox en su respectiva hoja de estilos.
  - En el pie de página (`HomeFooterComponent`), los caracteres de Fleur-de-lis unicode (`⚜`) se reemplazaron por un SVG de escudo medieval decorativo.

## **Canvas: Corrección de Click Derecho e Interrupción del Trazo**
- Se solventó el bug que provocaba que al hacer click derecho en mitad de un trazo de dibujo, la línea se visualizara localmente pero no se transmitiera a los otros jugadores por WebSocket.
  - Se filtró el evento `mousedown` en el canvas para responder únicamente al botón izquierdo del ratón (`event.button === 0`), evitando que el click derecho reiniciara el buffer del trazo.
  - Se previno el comportamiento predeterminado del menú contextual nativo del navegador sobre el canvas mediante `(contextmenu)="$event.preventDefault()"`.
