### PR TITLE
fix: anfitrion en priv games

### DIFF
--- a/backend/src/main/java/com/impaintor/feature/room/controller/RoomController.java
+++ b/backend/src/main/java/com/impaintor/feature/room/controller/RoomController.java
@@ -87,6 +87,11 @@ public class RoomController {
             return ResponseEntity.badRequest().body("La sala está llena");
         }
 
+        // El primer jugador en unirse es el anfitrión
+        if (room.getHostId() == null) {
+            room.setHostId(user.getId());
+        }
+
         room.getPlayersNames().add(user);
         roomRepository.save(room);
 

--- a/backend/src/main/java/com/impaintor/feature/room/models/Room.java
+++ b/backend/src/main/java/com/impaintor/feature/room/models/Room.java
@@ -51,6 +51,9 @@ public class Room {
     @Column(name = "size")
     private Integer size;
 
+    @Column(name = "host_id")
+    private Long hostId;
+
     @Column(name="impostor_tries")
     private Integer impostorTries;
 
@@ -184,6 +187,14 @@ public class Room {
 
     public void setSize(Integer size) {
         this.size = size;
+    }
+
+    public Long getHostId() {
+        return hostId;
+    }
+
+    public void setHostId(Long hostId) {
+        this.hostId = hostId;
     }
 
     public WordGroup getWordGroup() {

--- a/frontend/src/app/features/room/lobby/lobby.ts
+++ b/frontend/src/app/features/room/lobby/lobby.ts
@@ -22,6 +22,7 @@ interface RoomDetails {
   gameState: 'WAITING' | 'PLAYING' | 'FINISHED';
   impostorTries: number | null;
   drawTime: number | null;
+  hostId: number | null;
   playersNames: { id: number; username: string; avatarData?: string }[];
 }
 
@@ -75,11 +76,12 @@ export class Lobby implements OnInit, OnDestroy {
       next: (room) => {
         if (room.size) this.roomSize.set(room.size);
 
-        // Map backend User objects to lobby Player interface. The creator/first to join is host.
+        // Map backend User objects to lobby Player interface.
+        // The host is determined by the persistent hostId from the backend.
         this.players.set(
-          room.playersNames.map((u, index) => ({ 
+          room.playersNames.map((u) => ({ 
             username: u.username, 
-            isHost: index === 0,
+            isHost: u.id === room.hostId,
             avatarUrl: u.avatarData
           }))
         );
@@ -91,7 +93,7 @@ export class Lobby implements OnInit, OnDestroy {
         });
 
         const currentUser = this.authService.getCurrentUser();
-        if (currentUser && room.playersNames.length > 0 && room.playersNames[0].username === currentUser.username) {
+        if (currentUser && room.hostId === currentUser.id) {
           this.isHost.set(true);
         }
 
@@ -113,15 +115,15 @@ export class Lobby implements OnInit, OnDestroy {
         next: (room) => {
           if (room.playersNames) {
             this.players.set(
-              room.playersNames.map((u: any, index: number) => ({ 
+              room.playersNames.map((u: any) => ({ 
                 username: u.username, 
-                isHost: index === 0,
+                isHost: u.id === room.hostId,
                 avatarUrl: u.avatarData
               }))
             );
 
             const currentUser = this.authService.getCurrentUser();
-            if (currentUser && room.playersNames.length > 0 && room.playersNames[0].username === currentUser.username) {
+            if (currentUser && room.hostId === currentUser.id) {
               this.isHost.set(true);
             } else {
               this.isHost.set(false);


### PR DESCRIPTION
Esta pull request introduce una asignación persistente del host para las salas de juego. Ahora, el primer usuario que entra a una sala se establece como host en el backend, y esta información se utiliza de forma consistente en el frontend para identificar al anfitrión, en lugar de depender del orden de los jugadores. Esto garantiza que el host siga identificado correctamente incluso si cambia la lista de jugadores.

## **Backend: Asignación y Persistencia del Host**
- Se añadió un nuevo campo `hostId` al modelo `Room`, junto con sus correspondientes métodos getter y setter, asegurando además que se almacene en la base de datos. [[1]](diffhunk://#diff-2953eb3b7ab6d65f415e5ad1c9ed1e420159ecd4650d200f5792c65648bed7f0R54-R56) [[2]](diffhunk://#diff-2953eb3b7ab6d65f415e5ad1c9ed1e420159ecd4650d200f5792c65648bed7f0R192-R199)

- Se actualizó la lógica de `joinRoom` en `RoomController` para que el primer jugador que entre en una sala sea asignado automáticamente como host, guardando su ID de usuario en el campo `hostId`.

## **Frontend: Actualización de la Lógica de Identificación del Host**
- Se actualizaron la interfaz `RoomDetails` y la lógica del lobby para utilizar el nuevo campo `hostId` enviado desde el backend a la hora de determinar quién es el host, reemplazando la lógica anterior basada en el orden de los jugadores. [[1]](diffhunk://#diff-4b715648e4c9d903c4e016e5e9f3531e72e5dac136f82987ed20b83b6d1039f4R25) [[2]](diffhunk://#diff-4b715648e4c9d903c4e016e5e9f3531e72e5dac136f82987ed20b83b6d1039f4L78-R84) [[3]](diffhunk://#diff-4b715648e4c9d903c4e016e5e9f3531e72e5dac136f82987ed20b83b6d1039f4L94-R96) [[4]](diffhunk://#diff-4b715648e4c9d903c4e016e5e9f3531e72e5dac136f82987ed20b83b6d1039f4L116-R126)

Estos cambios mejoran la fiabilidad de la identificación del host y aseguran un comportamiento consistente incluso cuando cambia la composición de jugadores en la sala.