### PR TITLE
Revert "refactor: update game initialization scheduler logic and enha…

### DIFF
--- a/backend/src/main/java/com/impaintor/feature/realtime/security/JwtTokenValidator.java
+++ b/backend/src/main/java/com/impaintor/feature/realtime/security/JwtTokenValidator.java
@@ -24,11 +24,9 @@ import io.jsonwebtoken.security.Keys;
 public class JwtTokenValidator implements TokenValidator {
 
     private final SecretKey key;
-    private final String expectedIssuer;
 
     public JwtTokenValidator(RealtimeProperties props) {
         this.key = Keys.hmacShaKeyFor(props.jwt().secret().getBytes(StandardCharsets.UTF_8));
-        this.expectedIssuer = props.jwt().issuer();
     }
 
     @Override
@@ -39,7 +37,6 @@ public class JwtTokenValidator implements TokenValidator {
         try {
             Claims claims = Jwts.parser()
                     .verifyWith(key)
-                    .requireIssuer(expectedIssuer)
                     .build()
                     .parseSignedClaims(rawToken)
                     .getPayload();

--- a/backend/src/test/java/com/impaintor/feature/game/service/GameServiceTest.java
+++ b/backend/src/test/java/com/impaintor/feature/game/service/GameServiceTest.java
@@ -90,9 +90,7 @@ class GameServiceTest {
         assertThat(room.getSecretWord()).isEqualTo(gameState.getSecretWord());
         assertThat(room.getHintWord()).isEqualTo(gameState.getHintWord());
 
-        ArgumentCaptor<Runnable> initRunnableCaptor = ArgumentCaptor.forClass(Runnable.class);
-        verify(scheduler).schedule(initRunnableCaptor.capture(), eq(3L), eq(TimeUnit.SECONDS));
-        initRunnableCaptor.getValue().run();
+        verify(scheduler).schedule(any(Runnable.class), eq(30L), eq(TimeUnit.SECONDS));
 
         ArgumentCaptor<RoleAssignment> roleCaptor = ArgumentCaptor.forClass(RoleAssignment.class);
         verify(realtimePublisher, times(3)).sendRoleAssignment(anyLong(), roleCaptor.capture());
@@ -127,14 +125,10 @@ class GameServiceTest {
         GameState second = service.initializeGame(ROOM_CODE);
 
         assertThat(second).isSameAs(first);
-        verify(roomRepository, times(1)).findByRoomCode(ROOM_CODE);
+        verify(roomRepository, times(2)).findById(ROOM_CODE);
         verify(wordGroupRepository, times(1)).findRandom();
         verify(roomRepository, times(1)).save(room);
-        
-        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
-        verify(scheduler, times(1)).schedule(runnableCaptor.capture(), eq(3L), eq(TimeUnit.SECONDS));
-        runnableCaptor.getValue().run();
-        
+        verify(scheduler, times(1)).schedule(any(Runnable.class), eq(30L), eq(TimeUnit.SECONDS));
         verify(realtimePublisher, times(3)).sendRoleAssignment(anyLong(), any(RoleAssignment.class));
     }
 

--- a/backend/src/test/java/com/impaintor/feature/realtime/security/JwtTokenValidatorTest.java
+++ b/backend/src/test/java/com/impaintor/feature/realtime/security/JwtTokenValidatorTest.java
@@ -71,8 +71,8 @@ class JwtTokenValidatorTest {
     private static String signedToken(Long id, String username, Instant exp, String secret, String issuer) {
         SecretKey key = Keys.hmacShaKeyFor(secret.getBytes(UTF_8));
         return Jwts.builder()
-                .subject(username)
-                .claim("uid", id)
+                .subject(String.valueOf(id))
+                .claim("username", username)
                 .issuer(issuer)
                 .expiration(Date.from(exp))
                 .signWith(key)


### PR DESCRIPTION
This pull request makes several important updates to the backend, primarily focusing on simplifying JWT token validation and adjusting game initialization timing in tests. The changes remove issuer validation from JWT handling, update test expectations to reflect a new game initialization delay, and adjust token generation in test utilities.

**JWT Token Validation Simplification:**

* Removed the requirement to check the JWT issuer in `JwtTokenValidator`, simplifying the validation logic and constructor. (`JwtTokenValidator.java`) [[1]](diffhunk://#diff-d155da07b82723f45842122cdede310caa412c56d60aa4b0c794bcfade85eba1L27-L31) [[2]](diffhunk://#diff-d155da07b82723f45842122cdede310caa412c56d60aa4b0c794bcfade85eba1L42)

**Game Initialization Timing Adjustments in Tests:**

* Updated tests in `GameServiceTest` to expect a 30-second delay (instead of 3 seconds) when scheduling the first game turn. This affects both the `initializeGame_selectsWordGroup_assignsRoles_andSchedulesFirstTurn` and `initializeGame_isIdempotent_whenCalledTwiceForSameRoom` tests. (`GameServiceTest.java`) [[1]](diffhunk://#diff-8f20f6a68dd8da357987b8510294abcec3cf6e8203dcc9596804ce3c1d13749bL93-R93) [[2]](diffhunk://#diff-8f20f6a68dd8da357987b8510294abcec3cf6e8203dcc9596804ce3c1d13749bL130-R131)

**Test Utility Update:**

* Changed the `signedToken` test utility method to set the JWT subject to the user ID and the username as a claim, aligning with the new expected token structure. (`JwtTokenValidatorTest.java`)